### PR TITLE
Job Deletion when job are not referenced by triggers.

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/Constants.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/Constants.java
@@ -4,6 +4,7 @@ public interface Constants {
 
   public static final String JOB_DESCRIPTION = "jobDescription";
   public static final String JOB_CLASS = "jobClass";
+  public static final String JOB_DURABILITY = "durability";
   public static final String TRIGGER_CALENDAR_NAME = "calendarName";
   public static final String TRIGGER_DESCRIPTION = "description";
   public static final String TRIGGER_END_TIME = "endTime";


### PR DESCRIPTION
I've added this feature.

This is the behavior used by the JDBCStore supplied with quartz. Hover, job durability is not yet implemented in mongodbjobstore as far as I can see, so there is no way to have a durable job. (Before this patch, all jobs were durable, albeit this was a bug because durability is false by default.)

I'll try to implement the durable property for jobs in a future pull request.

Please let me know if there is anything else that I should add.

Best,
Vlad.
