### PR TITLE
Fixed problem that JobExecutionContext.getPreviousFireTime() returns the actual execution time

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -548,10 +548,7 @@ public class MongoDBJobStore implements JobStore, Constants {
         if (cal == null)
           continue;
       }
-
-      trigger.triggered(cal);
-      storeTrigger(trigger, true);
-
+      
       Date prevFireTime = trigger.getPreviousFireTime();
 
       TriggerFiredBundle bndle = new TriggerFiredBundle(retrieveJob(
@@ -566,6 +563,10 @@ public class MongoDBJobStore implements JobStore, Constants {
       }
 
       results.add(new TriggerFiredResult(bndle));
+      
+      trigger.triggered(cal);
+      storeTrigger(trigger, true);
+
     }
     return results;
   }


### PR DESCRIPTION
Fixed problem that JobExecutionContext.getPreviousFireTime() returns the actual execution time.

This seems to be because the trigger is updated before the TriggerFiredBundle, is created.
I assume the TriggerFiredBundle holds the data available later in a job implementation via JobExecutionContext.

Thus the update of the trigger needs to happen after the TriggerFiredBundle has been created with trigger values.
