### PR TITLE
Add instance id to all locks.

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -506,6 +506,7 @@ public class MongoDBJobStore implements JobStore, Constants {
         lock = new BasicDBObject();
         lock.put(LOCK_KEY_NAME, dbObj.get(KEY_NAME));
         lock.put(LOCK_KEY_GROUP, dbObj.get(KEY_GROUP));
+        lock.put(LOCK_INSTANCE_ID, instanceId);
 
         DBObject existingLock;
         DBCursor lockCursor = locksCollection.find(lock);


### PR DESCRIPTION
Remove lock always searches for the instance id, and here the instance id is not added.

In certain corner cases this causes huge pain, as one instance tries to delete the lock, fails, and then acquires the same lock, resulting in a rather nasty loop.

If you think there is a better way to do this, please let me know.
