### PR TITLE
Small fix related to previous change

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -506,7 +506,6 @@ public class MongoDBJobStore implements JobStore, Constants {
         lock = new BasicDBObject();
         lock.put(LOCK_KEY_NAME, dbObj.get(KEY_NAME));
         lock.put(LOCK_KEY_GROUP, dbObj.get(KEY_GROUP));
-        lock.put(LOCK_INSTANCE_ID, instanceId);
 
         DBObject existingLock;
         DBCursor lockCursor = locksCollection.find(lock);
@@ -565,7 +564,6 @@ public class MongoDBJobStore implements JobStore, Constants {
       if (job.isConcurrentExectionDisallowed()) {
         throw new UnsupportedOperationException("ConcurrentExecutionDisallowed is not supported currently.");
       }
-
       results.add(new TriggerFiredResult(bndle));
     }
     return results;
@@ -913,7 +911,9 @@ public class MongoDBJobStore implements JobStore, Constants {
     BasicDBObject lock = new BasicDBObject();
     lock.put(LOCK_KEY_NAME, trigger.getKey().getName());
     lock.put(LOCK_KEY_GROUP, trigger.getKey().getGroup());
-    lock.put(LOCK_INSTANCE_ID, instanceId);
+
+    // Coment this out, as expired trigger locks should be deleted by any another instance
+    // lock.put(LOCK_INSTANCE_ID, instanceId);
 
     locksCollection.remove(lock);
     log.debug("Trigger lock " + trigger.getKey() + "." + instanceId + " removed.");


### PR DESCRIPTION
My previous changed assumed that the expired locks are only tried to be removed by the same instance that created them. This is not true, so I just changed that locks are removed only based on their id and not based on the instance ID.

I think this is desired, as the instance id could easily change from one run to another, and the expired locks would be zombies as they are not matched by the new instance id.

Please feel free to suggest another approach to this if you feel this is not right.
