### PR TITLE
Fix for null pointer on new startup with empty job collection

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -150,6 +150,10 @@ public class MongoDBJobStore implements JobStore, Constants {
   @SuppressWarnings("unchecked")
   public JobDetail retrieveJob(JobKey jobKey) throws JobPersistenceException {
     DBObject dbObject = findJobDocumentByKey(jobKey);
+    if (dbObject == null) {
+      //Return null if job does not exist, per interface
+      return null;
+    }
 
     try {
       Class<Job> jobClass = (Class<Job>) getJobClassLoader().loadClass((String) dbObject.get(JOB_CLASS));


### PR DESCRIPTION
Small fix to return null when job doesn't yet exist (per interface). Fixes null pointer when getting jobClass from null dbObject below. Experienced this on fresh startup with empty job collection
