### PR TITLE
Report warning instead of error on 'removing lock and retrying trigger acquisition'

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -522,7 +522,7 @@ public class MongoDBJobStore implements JobStore, Constants {
 
         // support for trigger lock expirations
         if (isTriggerLockExpired(existingLock)) {
-          log.error("Lock for trigger " + trigger.getKey() + " is expired - removing lock and retrying trigger acquisition");
+          log.warn("Lock for trigger " + trigger.getKey() + " is expired - removing lock and retrying trigger acquisition");
           removeTriggerLock(trigger);
           return acquireNextTriggers(noLaterThan, maxCount, timeWindow);
         }


### PR DESCRIPTION
Hi,

This message shouldn't be reported as 'error', is it right?

Thanks,
Michael
