### PR TITLE
Fix for Issue #27

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -853,8 +853,6 @@ public class MongoDBJobStore implements JobStore, Constants {
     keys = new BasicDBObject();
     keys.put(KEY_NAME, 1);
     keys.put(KEY_GROUP, 1);
-    keys.put(TRIGGER_NEXT_FIRE_TIME, 1);
-    keys.put(TRIGGER_PREVIOUS_FIRE_TIME, 1);
     triggerCollection.ensureIndex(keys, null, true);
 
     keys = new BasicDBObject();


### PR DESCRIPTION
Fix for Issue #27: Removing next fire time and previous fire time as part of the (unique) index on the trigger collection.  Because these values are always changing (as the triggers update) this caused a bug where new triggers kept getting inserted, rather than updated.
