### PR TITLE
Add the missing setter for the job timeout property

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -61,7 +61,6 @@ public class MongoDBJobStore implements JobStore, Constants {
   private SchedulerSignaler signaler;
   protected long misfireThreshold = 5000l;
   private long triggerTimeoutMillis = 10 * 60 * 1000L;
-  // TODO.  This really ought to be configured.
   private long jobTimeoutMillis = 10 * 60 * 1000L;
   
   // Options for the Mongo client.
@@ -835,6 +834,9 @@ public class MongoDBJobStore implements JobStore, Constants {
     this.triggerTimeoutMillis = triggerTimeoutMillis;
   }
 
+  public void setJobTimeoutMillis(long jobTimeoutMillis) {
+	  this.jobTimeoutMillis = jobTimeoutMillis;
+  }
 
   //
   // Implementation


### PR DESCRIPTION
I need this property to be configurable via the quartz.properties -> the setter is just missing

(probably usefull too to update documentation about available MongoJobStore properties:
org.quartz.jobStore.jobTimeoutMillis=3600000
)

Notes others like "org.quartz.jobStore.jobTimeoutMillis" are missing too
