### PR TITLE
Corrected bug in triggering of Schedules 

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -655,6 +655,7 @@ public class MongoDBJobStore implements JobStore, Constants {
       }
 
       Date prevFireTime = trigger.getPreviousFireTime();
+      trigger.triggered(cal);
 
       TriggerFiredBundle bndle = new TriggerFiredBundle(retrieveJob(
           trigger), trigger, cal,


### PR DESCRIPTION
This is a possible fix for issue https://github.com/michaelklishin/quartz-mongodb/issues/68

This correction will 
1. Fix return of "null" in getScheduledFireTime() for the first time.
2. Make sure that the scheduledFireTime is correct for all triggers.
