### PR TITLE
Deleted trigerred() call in wrong place.

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -681,7 +681,6 @@ public class MongoDBJobStore implements JobStore, Constants {
           }
           
           results.add(new TriggerFiredResult(bndle));
-          trigger.triggered(cal);
           storeTrigger(trigger, true);
         }
         catch (DuplicateKey dk) {


### PR DESCRIPTION
trigerred() was being called another time (in wrong place).  Removed the call in wrong place. Retaining the one in correct place.

This change has been tested in my local env.

Actually, this was a change missed in commit of pull request https://github.com/michaelklishin/quartz-mongodb/pull/69
