### PR TITLE
Permanent false value of durability of retrieving jobs from JobStore

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -177,7 +177,8 @@ public class MongoDBJobStore implements JobStore, Constants {
 
       JobBuilder builder = JobBuilder.newJob(jobClass)
           .withIdentity((String) dbObject.get(KEY_NAME), (String) dbObject.get(KEY_GROUP))
-          .withDescription((String) dbObject.get(JOB_DESCRIPTION));
+          .withDescription((String) dbObject.get(JOB_DESCRIPTION))
+          .storeDurably((Boolean)dbObject.get(JOB_DURABILITY));
 
       JobDataMap jobData = new JobDataMap();
       
@@ -191,6 +192,7 @@ public class MongoDBJobStore implements JobStore, Constants {
               && !key.equals(KEY_GROUP)
               && !key.equals(JOB_CLASS)
               && !key.equals(JOB_DESCRIPTION)
+              && !key.equals(JOB_DURABILITY)
               && !key.equals("_id")) {
             jobData.put(key, dbObject.get(key));
           }


### PR DESCRIPTION
issue:  permanent false value of durability of retrieving jobs from JobStore,  value of durability fall into the JobDataMap, and durability had default value(false)

fix: store value of durability from JobStore into appropriate property of JobDetail(not in JobDataMap)
