### PR TITLE
When storing a trigger, default to updating when replaceExisting is true

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -1191,13 +1191,13 @@ public class MongoDBJobStore implements JobStore, Constants {
     TriggerPersistenceHelper tpd = triggerPersistenceDelegateFor(newTrigger);
     trigger = (BasicDBObject) tpd.injectExtraPropertiesForInsert(newTrigger, trigger);
 
-    try {
-      triggerCollection.insert(trigger);
-    } catch (DuplicateKeyException key) {
-      if (replaceExisting) {
-        trigger.remove("_id");
-        triggerCollection.update(keyToDBObject(newTrigger.getKey()), trigger);
-      } else {
+    if (replaceExisting) {
+      trigger.remove("_id");
+      triggerCollection.update(keyToDBObject(newTrigger.getKey()), trigger);
+    } else {
+      try {
+        triggerCollection.insert(trigger);
+      } catch (DuplicateKeyException key) {
         throw new ObjectAlreadyExistsException(newTrigger);
       }
     }


### PR DESCRIPTION
In NewRelic, we are seeing DuplicateKey errors even though they are being handled by this code. If we know we want to replace, let's just go ahead an update. This could even be an upsert and we would not need to have the boolean, but why take all the fun? ;)