### PR TITLE
Migrate to mongo-java-driver 3.x

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/CalendarIntervalTriggerPersistenceHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/CalendarIntervalTriggerPersistenceHelper.java
@@ -1,7 +1,6 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBObject;
+import org.bson.Document;
 import org.quartz.DateBuilder.IntervalUnit;
 import org.quartz.impl.triggers.CalendarIntervalTriggerImpl;
 import org.quartz.spi.OperableTrigger;
@@ -17,18 +16,17 @@ public class CalendarIntervalTriggerPersistenceHelper implements TriggerPersiste
   }
 
   @Override
-  public DBObject injectExtraPropertiesForInsert(OperableTrigger trigger, DBObject original) {
+  public Document injectExtraPropertiesForInsert(OperableTrigger trigger, Document original) {
     CalendarIntervalTriggerImpl t = (CalendarIntervalTriggerImpl) trigger;
 
-    return BasicDBObjectBuilder.start(original.toMap()).
+    return new Document(original).
         append(TRIGGER_REPEAT_INTERVAL_UNIT, t.getRepeatIntervalUnit().name()).
         append(TRIGGER_REPEAT_INTERVAL, t.getRepeatInterval()).
-        append(TRIGGER_TIMES_TRIGGERED, t.getTimesTriggered()).
-        get();
+        append(TRIGGER_TIMES_TRIGGERED, t.getTimesTriggered());
   }
 
   @Override
-  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, DBObject stored) {
+  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, Document stored) {
     CalendarIntervalTriggerImpl t = (CalendarIntervalTriggerImpl) trigger;
 
     String repeatIntervalUnit = (String) stored.get(TRIGGER_REPEAT_INTERVAL_UNIT);

--- a/src/main/java/com/novemberain/quartz/mongodb/CronTriggerPersistenceHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/CronTriggerPersistenceHelper.java
@@ -1,7 +1,6 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBObject;
+import org.bson.Document;
 import org.quartz.CronExpression;
 import org.quartz.CronTrigger;
 import org.quartz.impl.triggers.CronTriggerImpl;
@@ -20,17 +19,16 @@ public class CronTriggerPersistenceHelper implements TriggerPersistenceHelper {
   }
 
   @Override
-  public DBObject injectExtraPropertiesForInsert(OperableTrigger trigger, DBObject original) {
+  public Document injectExtraPropertiesForInsert(OperableTrigger trigger, Document original) {
     CronTrigger t = (CronTrigger) trigger;
 
-    return BasicDBObjectBuilder.start(original.toMap()).
+    return new Document(original).
         append(TRIGGER_CRON_EXPRESSION, t.getCronExpression()).
-        append(TRIGGER_TIMEZONE, t.getTimeZone().getID()).
-        get();
+        append(TRIGGER_TIMEZONE, t.getTimeZone().getID());
   }
 
   @Override
-  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, DBObject stored) {
+  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, Document stored) {
     CronTriggerImpl t = (CronTriggerImpl) trigger;
 
     Object expression = stored.get(TRIGGER_CRON_EXPRESSION);

--- a/src/main/java/com/novemberain/quartz/mongodb/DailyTimeIntervalTriggerPersistenceHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/DailyTimeIntervalTriggerPersistenceHelper.java
@@ -27,11 +27,11 @@ public class DailyTimeIntervalTriggerPersistenceHelper implements TriggerPersist
         append(TRIGGER_REPEAT_INTERVAL_UNIT, t.getRepeatIntervalUnit().name()).
         append(TRIGGER_REPEAT_INTERVAL, t.getRepeatInterval()).
         append(TRIGGER_TIMES_TRIGGERED, t.getTimesTriggered()).
-        append(TRIGGER_START_TIME_OF_DAY, toDBObject(t.getStartTimeOfDay())).
-        append(TRIGGER_END_TIME_OF_DAY, toDBObject(t.getEndTimeOfDay()));
+        append(TRIGGER_START_TIME_OF_DAY, toDocument(t.getStartTimeOfDay())).
+        append(TRIGGER_END_TIME_OF_DAY, toDocument(t.getEndTimeOfDay()));
   }
 
-  private Document toDBObject(TimeOfDay tod) {
+  private Document toDocument(TimeOfDay tod) {
     return new Document().
         append("hour", tod.getHour()).
         append("minute", tod.getMinute()).
@@ -57,17 +57,17 @@ public class DailyTimeIntervalTriggerPersistenceHelper implements TriggerPersist
 
     Document startTOD = (Document) stored.get(TRIGGER_START_TIME_OF_DAY);
     if (startTOD != null) {
-      t.setStartTimeOfDay(fromDBObject(startTOD));
+      t.setStartTimeOfDay(fromDocument(startTOD));
     }
     Document endTOD = (Document) stored.get(TRIGGER_END_TIME_OF_DAY);
     if (endTOD != null) {
-      t.setEndTimeOfDay(fromDBObject(endTOD));
+      t.setEndTimeOfDay(fromDocument(endTOD));
     }
 
     return t;
   }
 
-  private TimeOfDay fromDBObject(Document endTOD) {
+  private TimeOfDay fromDocument(Document endTOD) {
     return new TimeOfDay((Integer) endTOD.get("hour"), (Integer) endTOD.get("minute"), (Integer) endTOD.get("second"));
   }
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/DailyTimeIntervalTriggerPersistenceHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/DailyTimeIntervalTriggerPersistenceHelper.java
@@ -1,7 +1,6 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBObject;
+import org.bson.Document;
 import org.quartz.DailyTimeIntervalTrigger;
 import org.quartz.TimeOfDay;
 import org.quartz.impl.triggers.DailyTimeIntervalTriggerImpl;
@@ -21,28 +20,26 @@ public class DailyTimeIntervalTriggerPersistenceHelper implements TriggerPersist
   }
 
   @Override
-  public DBObject injectExtraPropertiesForInsert(OperableTrigger trigger, DBObject original) {
+  public Document injectExtraPropertiesForInsert(OperableTrigger trigger, Document original) {
     DailyTimeIntervalTriggerImpl t = (DailyTimeIntervalTriggerImpl) trigger;
 
-    return BasicDBObjectBuilder.start(original.toMap()).
+    return new Document(original).
         append(TRIGGER_REPEAT_INTERVAL_UNIT, t.getRepeatIntervalUnit().name()).
         append(TRIGGER_REPEAT_INTERVAL, t.getRepeatInterval()).
         append(TRIGGER_TIMES_TRIGGERED, t.getTimesTriggered()).
         append(TRIGGER_START_TIME_OF_DAY, toDBObject(t.getStartTimeOfDay())).
-        append(TRIGGER_END_TIME_OF_DAY, toDBObject(t.getEndTimeOfDay())).
-        get();
+        append(TRIGGER_END_TIME_OF_DAY, toDBObject(t.getEndTimeOfDay()));
   }
 
-  private DBObject toDBObject(TimeOfDay tod) {
-    return BasicDBObjectBuilder.start().
+  private Document toDBObject(TimeOfDay tod) {
+    return new Document().
         append("hour", tod.getHour()).
         append("minute", tod.getMinute()).
-        append("second", tod.getSecond()).
-        get();
+        append("second", tod.getSecond());
   }
 
   @Override
-  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, DBObject stored) {
+  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, Document stored) {
     DailyTimeIntervalTriggerImpl t = (DailyTimeIntervalTriggerImpl) trigger;
 
     Object interval_unit = stored.get(TRIGGER_REPEAT_INTERVAL_UNIT);
@@ -58,11 +55,11 @@ public class DailyTimeIntervalTriggerPersistenceHelper implements TriggerPersist
       t.setTimesTriggered((Integer) timesTriggered);
     }
 
-    DBObject startTOD = (DBObject) stored.get(TRIGGER_START_TIME_OF_DAY);
+    Document startTOD = (Document) stored.get(TRIGGER_START_TIME_OF_DAY);
     if (startTOD != null) {
       t.setStartTimeOfDay(fromDBObject(startTOD));
     }
-    DBObject endTOD = (DBObject) stored.get(TRIGGER_END_TIME_OF_DAY);
+    Document endTOD = (Document) stored.get(TRIGGER_END_TIME_OF_DAY);
     if (endTOD != null) {
       t.setEndTimeOfDay(fromDBObject(endTOD));
     }
@@ -70,7 +67,7 @@ public class DailyTimeIntervalTriggerPersistenceHelper implements TriggerPersist
     return t;
   }
 
-  private TimeOfDay fromDBObject(DBObject endTOD) {
+  private TimeOfDay fromDBObject(Document endTOD) {
     return new TimeOfDay((Integer) endTOD.get("hour"), (Integer) endTOD.get("minute"), (Integer) endTOD.get("second"));
   }
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/DynamicMongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/DynamicMongoDBJobStore.java
@@ -4,7 +4,7 @@ import clojure.lang.DynamicClassLoader;
 
 import com.mongodb.MongoClient;
 
-public class DynamicMongoDBJobStore extends MongoDBJobStore implements org.quartz.spi.JobStore {
+public class DynamicMongoDBJobStore extends MongoDBJobStore {
 
   public DynamicMongoDBJobStore() {
     super();

--- a/src/main/java/com/novemberain/quartz/mongodb/GroupHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/GroupHelper.java
@@ -4,6 +4,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
+import org.bson.conversions.Bson;
 import org.quartz.impl.matchers.GroupMatcher;
 
 import java.util.HashSet;
@@ -23,7 +24,7 @@ public class GroupHelper {
   }
 
   public Set<String> groupsThatMatch(GroupMatcher<?> matcher) {
-    BasicDBObject filter = queryHelper.matchingKeysConditionFor(matcher);
+    Bson filter = queryHelper.matchingKeysConditionFor(matcher);
     return collection.distinct(KEY_GROUP, String.class).filter(filter).into(new HashSet<String>());
   }
 

--- a/src/main/java/com/novemberain/quartz/mongodb/GroupHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/GroupHelper.java
@@ -1,9 +1,8 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
+import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.quartz.impl.matchers.GroupMatcher;
 
@@ -15,10 +14,10 @@ import java.util.Set;
 import static com.novemberain.quartz.mongodb.Keys.KEY_GROUP;
 
 public class GroupHelper {
-  protected MongoCollection<BasicDBObject> collection;
+  protected MongoCollection<Document> collection;
   protected QueryHelper queryHelper;
 
-  public GroupHelper(MongoCollection<BasicDBObject> collection, QueryHelper queryHelper) {
+  public GroupHelper(MongoCollection<Document> collection, QueryHelper queryHelper) {
     this.collection = collection;
     this.queryHelper = queryHelper;
   }
@@ -28,8 +27,8 @@ public class GroupHelper {
     return collection.distinct(KEY_GROUP, String.class).filter(filter).into(new HashSet<String>());
   }
 
-  public List<DBObject> inGroupsThatMatch(GroupMatcher<?> matcher) {
-    return collection.find(Filters.in(KEY_GROUP, groupsThatMatch(matcher))).into(new LinkedList<DBObject>());
+  public List<Document> inGroupsThatMatch(GroupMatcher<?> matcher) {
+    return collection.find(Filters.in(KEY_GROUP, groupsThatMatch(matcher))).into(new LinkedList<Document>());
   }
 
   public Set<String> allGroups() {

--- a/src/main/java/com/novemberain/quartz/mongodb/JobLoader.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/JobLoader.java
@@ -1,0 +1,82 @@
+package com.novemberain.quartz.mongodb;
+
+import com.mongodb.DBObject;
+import org.quartz.*;
+
+import java.io.IOException;
+
+import static com.novemberain.quartz.mongodb.Keys.KEY_GROUP;
+import static com.novemberain.quartz.mongodb.Keys.KEY_NAME;
+
+public class JobLoader {
+
+    private ClassLoader jobClassLoader;
+
+    public JobLoader(ClassLoader jobClassLoader) {
+        this.jobClassLoader = jobClassLoader;
+    }
+
+    public JobDetail loadJobDetail(DBObject dbObject) throws JobPersistenceException {
+        try {
+            // Make it possible for subclasses to use custom class loaders.
+            // When Quartz jobs are implemented as Clojure records, the only way to use
+            // them without switching to gen-class is by using a
+            // clojure.lang.DynamicClassLoader instance.
+            @SuppressWarnings("unchecked")
+            Class<Job> jobClass = (Class<Job>) jobClassLoader
+                    .loadClass((String) dbObject.get(Constants.JOB_CLASS));
+
+            JobBuilder builder = createJobBuilder(dbObject, jobClass);
+            withDurability(dbObject, builder);
+            JobDataMap jobData = createJobDataMap(dbObject);
+            return builder.usingJobData(jobData).build();
+        } catch (ClassNotFoundException e) {
+            throw new JobPersistenceException("Could not load job class " + dbObject.get(Constants.JOB_CLASS), e);
+        } catch (IOException e) {
+            throw new JobPersistenceException("Could not load job class " + dbObject.get(Constants.JOB_CLASS), e);
+        }
+    }
+
+    private JobDataMap createJobDataMap(DBObject dbObject) throws IOException {
+        JobDataMap jobData = new JobDataMap();
+
+        String jobDataString = (String) dbObject.get(Constants.JOB_DATA);
+        if (jobDataString != null) {
+            SerialUtils.jobDataMapFromString(jobData, jobDataString);
+        } else {
+            for (String key : dbObject.keySet()) {
+                if (!key.equals(KEY_NAME)
+                        && !key.equals(KEY_GROUP)
+                        && !key.equals(Constants.JOB_CLASS)
+                        && !key.equals(Constants.JOB_DESCRIPTION)
+                        && !key.equals(Constants.JOB_DURABILITY)
+                        && !key.equals("_id")) {
+                    jobData.put(key, dbObject.get(key));
+                }
+            }
+        }
+
+        jobData.clearDirtyFlag();
+        return jobData;
+    }
+
+    private void withDurability(DBObject dbObject, JobBuilder builder) throws JobPersistenceException {
+        Object jobDurability = dbObject.get(Constants.JOB_DURABILITY);
+        if (jobDurability != null) {
+            if (jobDurability instanceof Boolean) {
+                builder.storeDurably((Boolean) jobDurability);
+            } else if (jobDurability instanceof String) {
+                builder.storeDurably(Boolean.valueOf((String) jobDurability));
+            } else {
+                throw new JobPersistenceException("Illegal value for " + Constants.JOB_DURABILITY + ", class "
+                        + jobDurability.getClass() + " not supported");
+            }
+        }
+    }
+
+    private JobBuilder createJobBuilder(DBObject dbObject, Class<Job> jobClass) {
+        return JobBuilder.newJob(jobClass)
+                .withIdentity((String) dbObject.get(KEY_NAME), (String) dbObject.get(KEY_GROUP))
+                .withDescription((String) dbObject.get(Constants.JOB_DESCRIPTION));
+    }
+}

--- a/src/main/java/com/novemberain/quartz/mongodb/JobLoader.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/JobLoader.java
@@ -1,6 +1,6 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.DBObject;
+import org.bson.Document;
 import org.quartz.*;
 
 import java.io.IOException;
@@ -16,7 +16,7 @@ public class JobLoader {
         this.jobClassLoader = jobClassLoader;
     }
 
-    public JobDetail loadJobDetail(DBObject dbObject) throws JobPersistenceException {
+    public JobDetail loadJobDetail(Document dbObject) throws JobPersistenceException {
         try {
             // Make it possible for subclasses to use custom class loaders.
             // When Quartz jobs are implemented as Clojure records, the only way to use
@@ -37,7 +37,7 @@ public class JobLoader {
         }
     }
 
-    private JobDataMap createJobDataMap(DBObject dbObject) throws IOException {
+    private JobDataMap createJobDataMap(Document dbObject) throws IOException {
         JobDataMap jobData = new JobDataMap();
 
         String jobDataString = (String) dbObject.get(Constants.JOB_DATA);
@@ -60,7 +60,7 @@ public class JobLoader {
         return jobData;
     }
 
-    private void withDurability(DBObject dbObject, JobBuilder builder) throws JobPersistenceException {
+    private void withDurability(Document dbObject, JobBuilder builder) throws JobPersistenceException {
         Object jobDurability = dbObject.get(Constants.JOB_DURABILITY);
         if (jobDurability != null) {
             if (jobDurability instanceof Boolean) {
@@ -74,9 +74,9 @@ public class JobLoader {
         }
     }
 
-    private JobBuilder createJobBuilder(DBObject dbObject, Class<Job> jobClass) {
+    private JobBuilder createJobBuilder(Document dbObject, Class<Job> jobClass) {
         return JobBuilder.newJob(jobClass)
-                .withIdentity((String) dbObject.get(KEY_NAME), (String) dbObject.get(KEY_GROUP))
-                .withDescription((String) dbObject.get(Constants.JOB_DESCRIPTION));
+                .withIdentity(dbObject.getString(KEY_NAME), dbObject.getString(KEY_GROUP))
+                .withDescription(dbObject.getString(Constants.JOB_DESCRIPTION));
     }
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/Keys.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/Keys.java
@@ -9,6 +9,8 @@ import org.quartz.TriggerKey;
 import org.quartz.spi.OperableTrigger;
 import org.quartz.utils.Key;
 
+import java.util.Date;
+
 public class Keys {
 
   public static final String KEY_NAME = "keyName";
@@ -60,5 +62,19 @@ public class Keys {
     trigger.put(Constants.TRIGGER_PRIORITY, newTrigger.getPriority());
     trigger.put(Constants.TRIGGER_START_TIME, newTrigger.getStartTime());
     return trigger;
+  }
+
+  public static BasicDBObject lockToBson(DBObject dbObj) {
+    BasicDBObject lock = new BasicDBObject();
+    lock.put(KEY_NAME, dbObj.get(KEY_NAME));
+    lock.put(KEY_GROUP, dbObj.get(KEY_GROUP));
+    return lock;
+  }
+
+  public static BasicDBObject createTriggerDbLock(DBObject dbObj, String instanceId) {
+    BasicDBObject lock = lockToBson(dbObj);
+    lock.put(Constants.LOCK_INSTANCE_ID, instanceId);
+    lock.put(Constants.LOCK_TIME, new Date());
+    return lock;
   }
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/Keys.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/Keys.java
@@ -11,20 +11,6 @@ public class Keys {
   public static final String KEY_NAME = "keyName";
   public static final String KEY_GROUP = "keyGroup";
 
-  // backwards compatibility...  Remove these in next 2.0 release.
-  @Deprecated
-  public static final String JOB_KEY_NAME = KEY_NAME;
-  @Deprecated
-  public static final String JOB_KEY_GROUP = KEY_GROUP;
-  @Deprecated
-  public static final String TRIGGER_KEY_NAME = KEY_NAME;
-  @Deprecated
-  public static final String TRIGGER_KEY_GROUP = KEY_GROUP;
-  @Deprecated
-  public static final String LOCK_KEY_NAME = KEY_NAME;
-  @Deprecated
-  public static final String LOCK_KEY_GROUP = KEY_GROUP;
-
   public static BasicDBObject keyToDBObject(Key<?> key) {
     BasicDBObject job = new BasicDBObject();
     job.put(KEY_NAME, key.getName());

--- a/src/main/java/com/novemberain/quartz/mongodb/Keys.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/Keys.java
@@ -1,7 +1,8 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
@@ -16,23 +17,22 @@ public class Keys {
   public static final String KEY_NAME = "keyName";
   public static final String KEY_GROUP = "keyGroup";
 
-  public static BasicDBObject keyToDBObject(Key<?> key) {
-    BasicDBObject job = new BasicDBObject();
-    job.put(KEY_NAME, key.getName());
-    job.put(KEY_GROUP, key.getGroup());
-    return job;
+  public static Bson keyToDBObject(Key<?> key) {
+    return Filters.and(
+            Filters.eq(KEY_NAME, key.getName()),
+            Filters.eq(KEY_GROUP, key.getGroup()));
   }
 
-  public static JobKey dbObjectToJobKey(DBObject dbo) {
-    return new JobKey((String) dbo.get(KEY_NAME), (String) dbo.get(KEY_GROUP));
+  public static JobKey dbObjectToJobKey(Document dbo) {
+    return new JobKey(dbo.getString(KEY_NAME), dbo.getString(KEY_GROUP));
   }
 
-  public static TriggerKey dbObjectToTriggerKey(DBObject dbo) {
-    return new TriggerKey((String) dbo.get(KEY_NAME), (String) dbo.get(KEY_GROUP));
+  public static TriggerKey dbObjectToTriggerKey(Document dbo) {
+    return new TriggerKey(dbo.getString(KEY_NAME), dbo.getString(KEY_GROUP));
   }
 
-  public static BasicDBObject convertToBson(JobDetail newJob, JobKey key) {
-    BasicDBObject job = new BasicDBObject();
+  public static Document convertToBson(JobDetail newJob, JobKey key) {
+    Document job = new Document();
     job.put(KEY_NAME, key.getName());
     job.put(KEY_GROUP, key.getGroup());
     job.put(KEY_NAME, key.getName());
@@ -44,8 +44,8 @@ public class Keys {
     return job;
   }
 
-  public static BasicDBObject convertToBson(OperableTrigger newTrigger, ObjectId jobId) {
-    BasicDBObject trigger = new BasicDBObject();
+  public static Document convertToBson(OperableTrigger newTrigger, ObjectId jobId) {
+    Document trigger = new Document();
     trigger.put(Constants.TRIGGER_STATE, Constants.STATE_WAITING);
     trigger.put(Constants.TRIGGER_CALENDAR_NAME, newTrigger.getCalendarName());
     trigger.put(Constants.TRIGGER_CLASS, newTrigger.getClass().getName());
@@ -64,15 +64,15 @@ public class Keys {
     return trigger;
   }
 
-  public static BasicDBObject lockToBson(DBObject dbObj) {
-    BasicDBObject lock = new BasicDBObject();
+  public static Document lockToBson(Document dbObj) {
+    Document lock = new Document();
     lock.put(KEY_NAME, dbObj.get(KEY_NAME));
     lock.put(KEY_GROUP, dbObj.get(KEY_GROUP));
     return lock;
   }
 
-  public static BasicDBObject createTriggerDbLock(DBObject dbObj, String instanceId) {
-    BasicDBObject lock = lockToBson(dbObj);
+  public static Document createTriggerDbLock(Document dbObj, String instanceId) {
+    Document lock = lockToBson(dbObj);
     lock.put(Constants.LOCK_INSTANCE_ID, instanceId);
     lock.put(Constants.LOCK_TIME, new Date());
     return lock;

--- a/src/main/java/com/novemberain/quartz/mongodb/Keys.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/Keys.java
@@ -17,17 +17,17 @@ public class Keys {
   public static final String KEY_NAME = "keyName";
   public static final String KEY_GROUP = "keyGroup";
 
-  public static Bson keyToDBObject(Key<?> key) {
+  public static Bson toFilter(Key<?> key) {
     return Filters.and(
             Filters.eq(KEY_NAME, key.getName()),
             Filters.eq(KEY_GROUP, key.getGroup()));
   }
 
-  public static JobKey dbObjectToJobKey(Document dbo) {
+  public static JobKey toJobKey(Document dbo) {
     return new JobKey(dbo.getString(KEY_NAME), dbo.getString(KEY_GROUP));
   }
 
-  public static TriggerKey dbObjectToTriggerKey(Document dbo) {
+  public static TriggerKey toTriggerKey(Document dbo) {
     return new TriggerKey(dbo.getString(KEY_NAME), dbo.getString(KEY_GROUP));
   }
 
@@ -64,15 +64,15 @@ public class Keys {
     return trigger;
   }
 
-  public static Document lockToBson(Document dbObj) {
+  public static Document lockToBson(Document doc) {
     Document lock = new Document();
-    lock.put(KEY_NAME, dbObj.get(KEY_NAME));
-    lock.put(KEY_GROUP, dbObj.get(KEY_GROUP));
+    lock.put(KEY_NAME, doc.get(KEY_NAME));
+    lock.put(KEY_GROUP, doc.get(KEY_GROUP));
     return lock;
   }
 
-  public static Document createTriggerDbLock(Document dbObj, String instanceId) {
-    Document lock = lockToBson(dbObj);
+  public static Document createTriggerDbLock(Document doc, String instanceId) {
+    Document lock = lockToBson(doc);
     lock.put(Constants.LOCK_INSTANCE_ID, instanceId);
     lock.put(Constants.LOCK_TIME, new Date());
     return lock;

--- a/src/main/java/com/novemberain/quartz/mongodb/Keys.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/Keys.java
@@ -2,8 +2,11 @@ package com.novemberain.quartz.mongodb;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+import org.bson.types.ObjectId;
+import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.TriggerKey;
+import org.quartz.spi.OperableTrigger;
 import org.quartz.utils.Key;
 
 public class Keys {
@@ -24,5 +27,38 @@ public class Keys {
 
   public static TriggerKey dbObjectToTriggerKey(DBObject dbo) {
     return new TriggerKey((String) dbo.get(KEY_NAME), (String) dbo.get(KEY_GROUP));
+  }
+
+  public static BasicDBObject convertToBson(JobDetail newJob, JobKey key) {
+    BasicDBObject job = new BasicDBObject();
+    job.put(KEY_NAME, key.getName());
+    job.put(KEY_GROUP, key.getGroup());
+    job.put(KEY_NAME, key.getName());
+    job.put(KEY_GROUP, key.getGroup());
+    job.put(Constants.JOB_DESCRIPTION, newJob.getDescription());
+    job.put(Constants.JOB_CLASS, newJob.getJobClass().getName());
+    job.put(Constants.JOB_DURABILITY, newJob.isDurable());
+    job.putAll(newJob.getJobDataMap());
+    return job;
+  }
+
+  public static BasicDBObject convertToBson(OperableTrigger newTrigger, ObjectId jobId) {
+    BasicDBObject trigger = new BasicDBObject();
+    trigger.put(Constants.TRIGGER_STATE, Constants.STATE_WAITING);
+    trigger.put(Constants.TRIGGER_CALENDAR_NAME, newTrigger.getCalendarName());
+    trigger.put(Constants.TRIGGER_CLASS, newTrigger.getClass().getName());
+    trigger.put(Constants.TRIGGER_DESCRIPTION, newTrigger.getDescription());
+    trigger.put(Constants.TRIGGER_END_TIME, newTrigger.getEndTime());
+    trigger.put(Constants.TRIGGER_FINAL_FIRE_TIME, newTrigger.getFinalFireTime());
+    trigger.put(Constants.TRIGGER_FIRE_INSTANCE_ID, newTrigger.getFireInstanceId());
+    trigger.put(Constants.TRIGGER_JOB_ID, jobId);
+    trigger.put(KEY_NAME, newTrigger.getKey().getName());
+    trigger.put(KEY_GROUP, newTrigger.getKey().getGroup());
+    trigger.put(Constants.TRIGGER_MISFIRE_INSTRUCTION, newTrigger.getMisfireInstruction());
+    trigger.put(Constants.TRIGGER_NEXT_FIRE_TIME, newTrigger.getNextFireTime());
+    trigger.put(Constants.TRIGGER_PREVIOUS_FIRE_TIME, newTrigger.getPreviousFireTime());
+    trigger.put(Constants.TRIGGER_PRIORITY, newTrigger.getPriority());
+    trigger.put(Constants.TRIGGER_START_TIME, newTrigger.getStartTime());
+    return trigger;
   }
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -1208,7 +1208,7 @@ public class MongoDBJobStore implements JobStore, Constants {
 
     if (replaceExisting) {
       trigger.remove("_id");
-      triggerCollection.updateOne(keyToDBObject(newTrigger.getKey()), trigger);
+      triggerCollection.replaceOne(keyToDBObject(newTrigger.getKey()), trigger);
     } else {
       try {
         triggerCollection.insertOne(trigger);
@@ -1237,7 +1237,7 @@ public class MongoDBJobStore implements JobStore, Constants {
     ObjectId objectId = null;
     
     if (object != null && replaceExisting) {
-      jobCollection.updateOne(keyDbo, job);
+      jobCollection.replaceOne(keyDbo, job);
     } else if (object == null) {
       try {
         jobCollection.insertOne(job);

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -16,8 +16,10 @@ import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOptions;
 import org.apache.commons.codec.binary.Base64;
+import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.quartz.Calendar;
 import org.quartz.*;
@@ -41,9 +43,7 @@ import static com.novemberain.quartz.mongodb.Keys.*;
 public class MongoDBJobStore implements JobStore, Constants {
   protected final Logger log = LoggerFactory.getLogger(getClass());
 
-  public static final BasicDBObject KEY_AND_GROUP_FIELDS = new BasicDBObject()
-      .append(KEY_GROUP, 1)
-      .append(KEY_NAME, 1);
+  private static final Bson KEY_AND_GROUP_FIELDS = Projections.include(KEY_GROUP, KEY_NAME);
 
   @Deprecated
   private static MongoClient overriddenMongo;
@@ -88,7 +88,6 @@ public class MongoDBJobStore implements JobStore, Constants {
   private QueryHelper queryHelper;
 
   public MongoDBJobStore(){
-
   }
 
   public MongoDBJobStore(final MongoClient mongo){

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -376,7 +376,7 @@ public class MongoDBJobStore implements JobStore, Constants {
 
   @Override
   public Set<JobKey> getJobKeys(GroupMatcher<JobKey> matcher) throws JobPersistenceException {
-    BasicDBObject query = queryHelper.matchingKeysConditionFor(matcher);
+    Bson query = queryHelper.matchingKeysConditionFor(matcher);
     MongoCursor<BasicDBObject> cursor = jobCollection.find(query).projection(KEY_AND_GROUP_FIELDS).iterator();
 
     Set<JobKey> result = new HashSet<JobKey>();
@@ -391,7 +391,7 @@ public class MongoDBJobStore implements JobStore, Constants {
 
   @Override
   public Set<TriggerKey> getTriggerKeys(GroupMatcher<TriggerKey> matcher) throws JobPersistenceException {
-    BasicDBObject query = queryHelper.matchingKeysConditionFor(matcher);
+    Bson query = queryHelper.matchingKeysConditionFor(matcher);
     MongoCursor<BasicDBObject> cursor = triggerCollection.find(query).projection(KEY_AND_GROUP_FIELDS).iterator();
 
     Set<TriggerKey> result = new HashSet<TriggerKey>();
@@ -570,7 +570,7 @@ public class MongoDBJobStore implements JobStore, Constants {
   private void doAcquireNextTriggers(Map<TriggerKey, OperableTrigger> triggers, Date noLaterThanDate, int maxCount)
       throws JobPersistenceException {
     QueryHelper queryHelper = new QueryHelper();
-    BasicDBObject query = queryHelper.createNextTriggerQuery(noLaterThanDate);
+    Bson query = queryHelper.createNextTriggerQuery(noLaterThanDate);
     BasicDBObject sort = new BasicDBObject(TRIGGER_NEXT_FIRE_TIME, 1);
 
     MongoCursor<BasicDBObject> cursor = triggerCollection.find(query).sort(sort).iterator();

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -734,7 +734,7 @@ public class MongoDBJobStore implements JobStore, Constants {
           results.add(new TriggerFiredResult(bundle));
           storeTrigger(trigger, true);
         }
-        catch (DuplicateKeyException dk) {
+        catch (MongoWriteException dk) {
           log.debug("Job disallows concurrent execution and is already running {}", job.getKey());
           
           // Remove the trigger lock
@@ -1212,7 +1212,7 @@ public class MongoDBJobStore implements JobStore, Constants {
     } else {
       try {
         triggerCollection.insertOne(trigger);
-      } catch (DuplicateKeyException key) {
+      } catch (MongoWriteException key) {
         throw new ObjectAlreadyExistsException(newTrigger);
       }
     }
@@ -1242,7 +1242,7 @@ public class MongoDBJobStore implements JobStore, Constants {
       try {
         jobCollection.insertOne(job);
         objectId = (ObjectId) job.get("_id");
-      } catch (DuplicateKeyException e) {
+      } catch (MongoWriteException e) {
         // Fine, find it and get its id.
         object = jobCollection.find(keyDbo).first();
         objectId = (ObjectId) object.get("_id");

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -1227,23 +1227,7 @@ public class MongoDBJobStore implements JobStore, Constants {
   }
 
   protected void storeTrigger(OperableTrigger newTrigger, ObjectId jobId, boolean replaceExisting) throws JobPersistenceException {
-    BasicDBObject trigger = new BasicDBObject();
-    trigger.put(TRIGGER_STATE, STATE_WAITING);
-    trigger.put(TRIGGER_CALENDAR_NAME, newTrigger.getCalendarName());
-    trigger.put(TRIGGER_CLASS, newTrigger.getClass().getName());
-    trigger.put(TRIGGER_DESCRIPTION, newTrigger.getDescription());
-    trigger.put(TRIGGER_END_TIME, newTrigger.getEndTime());
-    trigger.put(TRIGGER_FINAL_FIRE_TIME, newTrigger.getFinalFireTime());
-    trigger.put(TRIGGER_FIRE_INSTANCE_ID, newTrigger.getFireInstanceId());
-    trigger.put(TRIGGER_JOB_ID, jobId);
-    trigger.put(KEY_NAME, newTrigger.getKey().getName());
-    trigger.put(KEY_GROUP, newTrigger.getKey().getGroup());
-    trigger.put(TRIGGER_MISFIRE_INSTRUCTION, newTrigger.getMisfireInstruction());
-    trigger.put(TRIGGER_NEXT_FIRE_TIME, newTrigger.getNextFireTime());
-    trigger.put(TRIGGER_PREVIOUS_FIRE_TIME, newTrigger.getPreviousFireTime());
-    trigger.put(TRIGGER_PRIORITY, newTrigger.getPriority());
-    trigger.put(TRIGGER_START_TIME, newTrigger.getStartTime());
-    
+    BasicDBObject trigger = convertToBson(newTrigger, jobId);
     if (newTrigger.getJobDataMap().size() > 0) {
       try {
         String jobDataString = jobDataToString(newTrigger.getJobDataMap());
@@ -1272,20 +1256,11 @@ public class MongoDBJobStore implements JobStore, Constants {
     JobKey key = newJob.getKey();
 
     BasicDBObject keyDbo = keyToDBObject(key);
-    BasicDBObject job = keyToDBObject(key);
-
-    job.put(KEY_NAME, key.getName());
-    job.put(KEY_GROUP, key.getGroup());
-    job.put(JOB_DESCRIPTION, newJob.getDescription());
-    job.put(JOB_CLASS, newJob.getJobClass().getName());
-    job.put(JOB_DURABILITY, newJob.isDurable());
-
-    job.putAll(newJob.getJobDataMap());
+    BasicDBObject job = Keys.convertToBson(newJob, key);
 
     DBObject object = jobCollection.find(keyDbo).first();
-    
+
     ObjectId objectId = null;
-    
     if (object != null && replaceExisting) {
       jobCollection.replaceOne(keyDbo, job);
     } else if (object == null) {

--- a/src/main/java/com/novemberain/quartz/mongodb/QueryHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/QueryHelper.java
@@ -7,10 +7,19 @@ import org.bson.conversions.Bson;
 import org.quartz.impl.matchers.GroupMatcher;
 
 import java.util.Collection;
+import java.util.Date;
 
 import static com.novemberain.quartz.mongodb.Keys.KEY_GROUP;
 
 public class QueryHelper {
+
+  public BasicDBObject createNextTriggerQuery(Date noLaterThanDate) {
+    BasicDBObject query = new BasicDBObject();
+    query.put(Constants.TRIGGER_NEXT_FIRE_TIME, new BasicDBObject("$lte", noLaterThanDate));
+    query.put(Constants.TRIGGER_STATE, Constants.STATE_WAITING);
+    return query;
+  }
+
   public BasicDBObject matchingKeysConditionFor(GroupMatcher<?> matcher) {
     BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
 

--- a/src/main/java/com/novemberain/quartz/mongodb/QueryHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/QueryHelper.java
@@ -32,17 +32,17 @@ public class QueryHelper {
     return (BasicDBObject) builder.get();
   }
 
-  public BasicDBObject startsWithRegexDBObject(String compareToValue) {
+  private BasicDBObject startsWithRegexDBObject(String compareToValue) {
     //TODO rewrite using Filters
     return (BasicDBObject) BasicDBObjectBuilder.start().append("$regex", "^" + compareToValue + ".*").get();
   }
 
-  public BasicDBObject endsWithRegexDBObject(String compareToValue) {
+  private BasicDBObject endsWithRegexDBObject(String compareToValue) {
     //TODO rewrite using Filters
     return (BasicDBObject) BasicDBObjectBuilder.start().append("$regex", ".*" + compareToValue + "$").get();
   }
 
-  public BasicDBObject containsWithRegexDBObject(String compareToValue) {
+  private BasicDBObject containsWithRegexDBObject(String compareToValue) {
     //TODO rewrite using Filters
     return (BasicDBObject) BasicDBObjectBuilder.start().append("$regex", compareToValue).get();
   }

--- a/src/main/java/com/novemberain/quartz/mongodb/SerialUtils.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/SerialUtils.java
@@ -1,0 +1,73 @@
+package com.novemberain.quartz.mongodb;
+
+import org.apache.commons.codec.binary.Base64;
+import org.quartz.JobDataMap;
+
+import java.io.*;
+import java.util.Map;
+
+public class SerialUtils {
+
+    public static String jobDataToString(JobDataMap jobDataMap) throws IOException {
+        try {
+            byte[] bytes = stringMapToBytes(jobDataMap.getWrappedMap());
+            return Base64.encodeBase64String(bytes);
+        } catch (NotSerializableException e) {
+            throw new NotSerializableException(
+                    "Unable to serialize JobDataMap for insertion into " +
+                    "database because the value of property '" +
+                    getKeyOfNonSerializableStringMapEntry(jobDataMap.getWrappedMap()) +
+                    "' is not serializable: " + e.getMessage());
+        }
+    }
+
+    private static byte[] stringMapToBytes(Object object) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(object);
+        out.flush();
+        return baos.toByteArray();
+    }
+
+    public static String getKeyOfNonSerializableStringMapEntry(Map<String, ?> data) {
+        for (Map.Entry<String, ?> entry : data.entrySet()) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try {
+                ObjectOutputStream out = new ObjectOutputStream(baos);
+                out.writeObject(entry.getValue());
+                out.flush();
+            } catch (IOException e) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    public static void jobDataMapFromString(JobDataMap jobDataMap, String clob) throws IOException {
+        try {
+            byte[] bytes = Base64.decodeBase64(clob);
+            Map<String, ?> map = stringMapFromBytes(bytes);
+            jobDataMap.putAll(map);
+            jobDataMap.clearDirtyFlag();
+        } catch (NotSerializableException e) {
+            throw new NotSerializableException(
+                    "Unable to serialize JobDataMap for insertion into " +
+                    "database because the value of property '" +
+                    getKeyOfNonSerializableStringMapEntry(jobDataMap.getWrappedMap()) +
+                    "' is not serializable: " + e.getMessage());
+        } catch (ClassNotFoundException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+    private static Map<String, ?> stringMapFromBytes(byte[] bytes)
+            throws IOException, ClassNotFoundException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        @SuppressWarnings("unchecked")
+        Map<String, ?> map = (Map<String, ?>) ois.readObject();
+        ois.close();
+        return map;
+    }
+}

--- a/src/main/java/com/novemberain/quartz/mongodb/SimpleTriggerPersistenceHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/SimpleTriggerPersistenceHelper.java
@@ -1,7 +1,6 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBObject;
+import org.bson.Document;
 import org.quartz.SimpleTrigger;
 import org.quartz.impl.triggers.SimpleTriggerImpl;
 import org.quartz.spi.OperableTrigger;
@@ -17,18 +16,17 @@ public class SimpleTriggerPersistenceHelper implements TriggerPersistenceHelper 
   }
 
   @Override
-  public DBObject injectExtraPropertiesForInsert(OperableTrigger trigger, DBObject original) {
+  public Document injectExtraPropertiesForInsert(OperableTrigger trigger, Document original) {
     SimpleTrigger t = (SimpleTrigger) trigger;
 
-    return BasicDBObjectBuilder.start(original.toMap()).
+    return new Document(original).
         append(TRIGGER_REPEAT_COUNT, t.getRepeatCount()).
         append(TRIGGER_REPEAT_INTERVAL, t.getRepeatInterval()).
-        append(TRIGGER_TIMES_TRIGGERED, t.getTimesTriggered()).
-        get();
+        append(TRIGGER_TIMES_TRIGGERED, t.getTimesTriggered());
   }
 
   @Override
-  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, DBObject stored) {
+  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, Document stored) {
     SimpleTriggerImpl t = (SimpleTriggerImpl) trigger;
 
     Object repeatCount = stored.get(TRIGGER_REPEAT_COUNT);

--- a/src/main/java/com/novemberain/quartz/mongodb/TriggerGroupHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/TriggerGroupHelper.java
@@ -1,8 +1,8 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.BasicDBObject;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
+import org.bson.Document;
 import org.bson.types.ObjectId;
 
 import java.util.Collection;
@@ -14,13 +14,13 @@ import static com.novemberain.quartz.mongodb.Keys.KEY_GROUP;
 public class TriggerGroupHelper extends GroupHelper {
   public static final String JOB_ID = "jobId";
 
-  public TriggerGroupHelper(MongoCollection<BasicDBObject> collection, QueryHelper queryHelper) {
+  public TriggerGroupHelper(MongoCollection<Document> collection, QueryHelper queryHelper) {
     super(collection, queryHelper);
   }
 
   public List<String> groupsForJobId(ObjectId jobId) {
     return collection.distinct(KEY_GROUP, String.class)
-            .filter(new BasicDBObject(JOB_ID, jobId))
+            .filter(Filters.eq(JOB_ID, jobId))
             .into(new LinkedList<String>());
   }
 

--- a/src/main/java/com/novemberain/quartz/mongodb/TriggerPersistenceHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/TriggerPersistenceHelper.java
@@ -1,12 +1,12 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.DBObject;
+import org.bson.Document;
 import org.quartz.spi.OperableTrigger;
 
 public interface TriggerPersistenceHelper {
   boolean canHandleTriggerType(OperableTrigger trigger);
 
-  DBObject injectExtraPropertiesForInsert(OperableTrigger trigger, DBObject original);
+  Document injectExtraPropertiesForInsert(OperableTrigger trigger, Document original);
 
-  OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, DBObject stored);
+  OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, Document stored);
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/TriggerPersistenceHelper.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/TriggerPersistenceHelper.java
@@ -4,9 +4,9 @@ import com.mongodb.DBObject;
 import org.quartz.spi.OperableTrigger;
 
 public interface TriggerPersistenceHelper {
-  public boolean canHandleTriggerType(OperableTrigger trigger);
+  boolean canHandleTriggerType(OperableTrigger trigger);
 
-  public DBObject injectExtraPropertiesForInsert(OperableTrigger trigger, DBObject original);
+  DBObject injectExtraPropertiesForInsert(OperableTrigger trigger, DBObject original);
 
-  public OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, DBObject stored);
+  OperableTrigger setExtraPropertiesAfterInstantiation(OperableTrigger trigger, DBObject stored);
 }


### PR DESCRIPTION
Fixed two errors introduced during migration to the new  API.
Migrated use of Mongo API to 3.x. (Document, Filters, Sorts, etc.)
Part of code moved to separate methods/classes and renamed for readability.
Using Iterables instead of cursors and finds (they mostly took 1-2 docs from DB).
Didn't use Java 7 features, so no need to drop support for Java 6, yet.