### PR TITLE
bump MongoDB client to 3.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ notifications:
   recipients:
     - michaelklishin@me.com
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk7
+  - oraclejdk8
 services:
   - mongodb

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :test-selectors {:all     (constantly true)
                    :focus   :focus
                    :default (constantly true)}
-  :javac-options     ["-target" "1.6" "-source" "1.6" "-Xlint:deprecation"]
+  :javac-options     ["-target" "1.7" "-source" "1.7" "-Xlint:deprecation"]
   :profiles {:dev {:resource-paths ["src/test/resources"]
                    :dependencies [[org.clojure/clojure       "1.7.0"]
                                   [clojurewerkz/quartzite    "1.3.0"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :min-lein-version "2.4.2"
   :license {:name "Apache License 2.0"}
   :dependencies [[org.quartz-scheduler/quartz   "2.1.7"]
-                 [org.mongodb/mongo-java-driver "3.0.2"]
+                 [org.mongodb/mongo-java-driver "3.2.2"]
                  [joda-time/joda-time           "2.8.2"]
                  [commons-codec/commons-codec   "1.10"]]
   :java-source-paths ["src/main/java"]

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -611,7 +611,7 @@ public class MongoDBJobStore implements JobStore, Constants {
 
         Document lock = createTriggerDbLock(triggerDoc, instanceId);
         // A lock needs to be written with FSYNCED to be 100% effective across multiple servers
-        locksCollection.withWriteConcern(WriteConcern.FSYNCED).insertOne(lock);
+        locksCollection.withWriteConcern(WriteConcern.JOURNALED).insertOne(lock);
         
         log.info("Acquired trigger {}", trigger.getKey());
         triggers.put(trigger.getKey(), trigger);
@@ -682,7 +682,7 @@ public class MongoDBJobStore implements JobStore, Constants {
             lock.put(LOCK_INSTANCE_ID, instanceId);
             lock.put(LOCK_TIME, new Date());
             // A lock needs to be written with FSYNCED to be 100% effective across multiple servers
-            locksCollection.withWriteConcern(WriteConcern.FSYNCED).insertOne(lock);
+            locksCollection.withWriteConcern(WriteConcern.JOURNALED).insertOne(lock);
           }
           
           results.add(new TriggerFiredResult(bundle));
@@ -906,7 +906,7 @@ public class MongoDBJobStore implements JobStore, Constants {
 
   private MongoClientOptions createOptions() {
     MongoClientOptions.Builder optionsBuilder = MongoClientOptions.builder();
-    optionsBuilder.writeConcern(WriteConcern.SAFE);
+    optionsBuilder.writeConcern(WriteConcern.ACKNOWLEDGED);
 
     if (mongoOptionMaxConnectionsPerHost != null) optionsBuilder.connectionsPerHost(mongoOptionMaxConnectionsPerHost);
     if (mongoOptionConnectTimeoutMillis != null) optionsBuilder.connectTimeout(mongoOptionConnectTimeoutMillis);


### PR DESCRIPTION
still compatible with older MongoDB servers

* [Mongo Java Driver 3.3.2 Release info](https://github.com/mongodb/mongo-java-driver/releases/tag/r3.2.2)
* [MongoDB Java Driver Compatibility Matrix](https://docs.mongodb.org/ecosystem/drivers/driver-compatibility-reference/#java-driver-compatibility)