### PR TITLE
Implement CalendarDao.retrieveCalendar()

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/dao/CalendarDao.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/dao/CalendarDao.java
@@ -7,6 +7,7 @@ import com.mongodb.client.model.Projections;
 import com.novemberain.quartz.mongodb.util.SerialUtils;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.bson.types.Binary;
 import org.quartz.Calendar;
 import org.quartz.JobPersistenceException;
 
@@ -48,14 +49,16 @@ public class CalendarDao {
         return false;
     }
 
-    public Calendar retrieveCalendar(String calName) {
+    public Calendar retrieveCalendar(String calName) throws JobPersistenceException {
         if (calName != null) {
-            // TODO
-            throw new UnsupportedOperationException();
+            Bson searchObj = Filters.eq(CALENDAR_NAME, calName);
+            Document doc = calendarCollection.find(searchObj).first();
+            Binary serializedCalendar = doc.get(CALENDAR_SERIALIZED_OBJECT, Binary.class);
+            return SerialUtils.deserialize(serializedCalendar, Calendar.class);
         }
         return null;
     }
-
+    
     public void store(String name, Calendar calendar) throws JobPersistenceException {
         Document doc = new Document(CALENDAR_NAME, name)
                 .append(CALENDAR_SERIALIZED_OBJECT, SerialUtils.serialize(calendar));

--- a/src/main/java/com/novemberain/quartz/mongodb/trigger/MisfireHandler.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/trigger/MisfireHandler.java
@@ -30,7 +30,7 @@ public class MisfireHandler {
      * @param trigger    on which apply misfire logic
      * @return true when result of misfire is next fire time
      */
-    public boolean applyMisfireOnRecovery(OperableTrigger trigger) {
+    public boolean applyMisfireOnRecovery(OperableTrigger trigger) throws JobPersistenceException {
         if (trigger.getMisfireInstruction() == Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY) {
             return false;
         }
@@ -84,7 +84,7 @@ public class MisfireHandler {
         return calculateMisfireTime() < fireTime.getTime();
     }
 
-    private Calendar retrieveCalendar(OperableTrigger trigger) {
+    private Calendar retrieveCalendar(OperableTrigger trigger) throws JobPersistenceException {
         return calendarDao.retrieveCalendar(trigger.getCalendarName());
     }
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/util/SerialUtils.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/util/SerialUtils.java
@@ -1,6 +1,7 @@
 package com.novemberain.quartz.mongodb.util;
 
 import org.apache.commons.codec.binary.Base64;
+import org.bson.types.Binary;
 import org.quartz.Calendar;
 import org.quartz.JobDataMap;
 import org.quartz.JobPersistenceException;
@@ -25,6 +26,24 @@ public class SerialUtils {
             return byteStream.toByteArray();
         } catch (IOException e) {
             throw new JobPersistenceException("Could not serialize Calendar.", e);
+        }
+    }
+    
+    public static <T> T deserialize(Binary serialized, Class<T> clazz) throws JobPersistenceException {
+        ByteArrayInputStream byteStream = new ByteArrayInputStream(serialized.getData());
+        try {
+            ObjectInputStream objectStream = new ObjectInputStream(byteStream);
+            Object deserialized = objectStream.readObject();
+            objectStream.close();
+            if(clazz.isInstance(deserialized)) {
+                @SuppressWarnings("unchecked")
+                T obj = (T)deserialized;
+                return obj;
+            }
+        
+            throw new JobPersistenceException("Deserialized object is not of the desired type");
+        } catch (IOException | ClassNotFoundException e) {
+            throw new JobPersistenceException("Could not deserialize.", e);
         }
     }
 


### PR DESCRIPTION
CalendarDao.retrieveCalendar() was not implemented which meant that a job could not refer to a calendar. Implementing this allows, for example, a recurring job to be created that uses a HolidayCalendar to determine dates to be skipped.