### PR TITLE
Make Job Data serialization to base64 optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ to Clojure code, use:
 
 (this assumes Clojure jar is on classpath).
 
+### Job Data storage
+By default you are allowed to pass any `java.io.Serializable` objects inside `JobDataMap`.
+It will be serialized and stored as a `base64` string.
+
+If your `JobDataMap` only contains simple types, it may be stored directly inside MongoDB to save some performance.
+
+    org.quartz.jobStore.jobDataAsBase64=false
+
 ## Clustering
 
 To enable clustering set the following property:

--- a/src/main/java/com/novemberain/quartz/mongodb/Constants.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/Constants.java
@@ -3,6 +3,7 @@ package com.novemberain.quartz.mongodb;
 public interface Constants {
 
   String JOB_DATA = "jobData";
+  String JOB_DATA_PLAIN = "jobDataPlain";
   String TRIGGER_NEXT_FIRE_TIME = "nextFireTime";
   String TRIGGER_JOB_ID = "jobId";
   String TRIGGER_STATE = "state";

--- a/src/main/java/com/novemberain/quartz/mongodb/JobDataConverter.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/JobDataConverter.java
@@ -1,0 +1,108 @@
+package com.novemberain.quartz.mongodb;
+
+import com.novemberain.quartz.mongodb.util.SerialUtils;
+import org.bson.Document;
+import org.quartz.JobDataMap;
+import org.quartz.JobPersistenceException;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Converter between {@link JobDataMap} and mongo {@link Document}.
+ */
+public class JobDataConverter {
+
+	private final boolean base64Preferred;
+
+	/**
+	 * Constructs an instance of converter.
+	 * @param base64Preferred if preferred way to store job details is {@code base64}.
+	 */
+	public JobDataConverter(final boolean base64Preferred) {
+		this.base64Preferred = base64Preferred;
+	}
+
+	/**
+	 * Converts from job data map to document.
+	 * Depending on config, job data map can be stored
+	 * as a {@code base64} encoded or plain object.
+	 * @param from {@link JobDataMap} to convert from.
+	 * @param to mongo {@link Document} to populate. 
+	 * @throws JobPersistenceException if could not encode.
+	 */
+	public void toDocument(JobDataMap from, Document to) throws JobPersistenceException {
+		if (from.isEmpty()) {
+			return;
+		}
+		if (base64Preferred) {
+			String jobDataString;
+			try {
+				jobDataString = SerialUtils.serialize(from);
+			} catch (IOException e) {
+				throw new JobPersistenceException("Could not serialise job data.", e);
+			}
+			to.put(Constants.JOB_DATA, jobDataString);
+		} else {
+			to.put(Constants.JOB_DATA_PLAIN, from.getWrappedMap());
+		}
+	}
+
+	/**
+	 * Converts from document to job data map.
+	 * If {@code base64} is preferred, tries
+	 * to decode from '{@value Constants#JOB_DATA}' field.
+	 * Otherwise, first reads a plain object from 
+	 * '{@value Constants#JOB_DATA_PLAIN}' field, or,
+	 * if not present, falls back to {@code base64} field.
+	 * @param from mongo {@link Document} to read from.
+	 * @param to {@link JobDataMap} to populate.
+	 * @return if {@link JobDataMap} has been populated.
+	 * @throws JobPersistenceException if could not decode.
+	 */
+	public boolean toJobData(Document from, JobDataMap to) throws JobPersistenceException {
+		if (base64Preferred) {
+			return toJobDataFromBase64(from, to);
+		} else {
+			if (toJobDataFromField(from, to)) {
+				return true;
+			}
+			return toJobDataFromBase64(from, to);
+		}
+	}
+
+	/**
+	 * Converts from document to job data map
+	 * reading {@code base64} encoded field
+	 * '{@value Constants#JOB_DATA}'.
+	 */
+	private boolean toJobDataFromBase64(Document from, JobDataMap to) throws JobPersistenceException {
+		String jobDataBase64String = from.getString(Constants.JOB_DATA);
+		if (jobDataBase64String == null) {
+			return false;
+		}
+		Map<String, ?> jobDataMap;
+		try {
+			jobDataMap = SerialUtils.deserialize(null, jobDataBase64String);
+		} catch (IOException e) {
+			throw new JobPersistenceException("Could not deserialize job data.", e);
+		}
+		to.putAll(jobDataMap);
+		return true;
+	}
+
+	/**
+	 * Converts from document to job data map
+	 * reading a plain object from field
+	 * '{@value Constants#JOB_DATA_PLAIN}'.
+	 */
+	private boolean toJobDataFromField(Document from, JobDataMap to) {
+		@SuppressWarnings("unchecked")
+		Map<String, ?> jobDataMap = from.get(Constants.JOB_DATA_PLAIN, Map.class);
+		if (jobDataMap == null) {
+			return false;
+		}
+		to.putAll(jobDataMap);
+		return true;
+	}
+}

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -42,6 +42,7 @@ public class MongoDBJobStore implements JobStore, Constants {
     long jobTimeoutMillis = 10 * 60 * 1000L;
     private boolean clustered = false;
     long clusterCheckinIntervalMillis = 7500;
+    boolean jobDataAsBase64 = true;
 
     // Options for the Mongo client.
     Boolean mongoOptionSocketKeepAlive;
@@ -144,6 +145,33 @@ public class MongoDBJobStore implements JobStore, Constants {
      */
     public void setClusterCheckinInterval(long clusterCheckinInterval) {
         this.clusterCheckinIntervalMillis = clusterCheckinInterval;
+    }
+
+    public boolean isJobDataAsBase64() {
+
+        return jobDataAsBase64;
+    }
+
+    /**
+     * Configures the way job data is stored. {@link JobDetail}'s
+     * or {@link Trigger}'s {@link JobDataMap} can be represented
+     * as a {@code Map<String,Object>}.
+     * <ul>
+     * <li><b>{@code true}</b> (default) - Serialize map with
+     * {@link java.io.ObjectOutputStream ObjectOutputStream}
+     * and store as {@code base64} encoded string in field
+     * '{@value Constants#JOB_DATA}'. Map may contain any
+     * {@link java.io.Serializable Serializable} object
+     * internally, but will have some performance impact.</li>
+     * <li><b>{@code false}</b> - Store map directly in
+     * '{@value Constants#JOB_DATA_PLAIN}' field. Use this
+     * option is you only store simple types in job data
+     * map for better performance.</li>
+     * </ul>
+     */
+    public void setJobDataAsBase64(boolean jobDataAsBase64) {
+
+        this.jobDataAsBase64 = jobDataAsBase64;
     }
 
     /**

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoStoreAssembler.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoStoreAssembler.java
@@ -48,9 +48,11 @@ public class MongoStoreAssembler {
 
         db = mongoConnector.selectDatabase(jobStore.dbName);
 
-        jobDao = createJobDao(jobStore, loadHelper);
+        JobDataConverter jobDataConverter = new JobDataConverter(jobStore.isJobDataAsBase64());
 
-        triggerConverter = new TriggerConverter(jobDao);
+        jobDao = createJobDao(jobStore, loadHelper, jobDataConverter);
+
+        triggerConverter = new TriggerConverter(jobDao, jobDataConverter);
 
         triggerDao = createTriggerDao(jobStore);
         calendarDao = createCalendarDao(jobStore);
@@ -90,8 +92,8 @@ public class MongoStoreAssembler {
         return new CalendarDao(getCollection(jobStore, "calendars"));
     }
 
-    private JobDao createJobDao(MongoDBJobStore jobStore, ClassLoadHelper loadHelper) {
-        JobConverter jobConverter = new JobConverter(jobStore.getClassLoaderHelper(loadHelper));
+    private JobDao createJobDao(MongoDBJobStore jobStore, ClassLoadHelper loadHelper, JobDataConverter jobDataConverter) {
+        JobConverter jobConverter = new JobConverter(jobStore.getClassLoaderHelper(loadHelper), jobDataConverter);
         return new JobDao(getCollection(jobStore, "jobs"), queryHelper, jobConverter);
     }
 

--- a/src/main/java/com/novemberain/quartz/mongodb/dao/JobDao.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/dao/JobDao.java
@@ -6,7 +6,6 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.novemberain.quartz.mongodb.JobConverter;
-import com.novemberain.quartz.mongodb.cluster.TriggerRecoverer;
 import com.novemberain.quartz.mongodb.util.GroupHelper;
 import com.novemberain.quartz.mongodb.util.Keys;
 import com.novemberain.quartz.mongodb.util.QueryHelper;
@@ -16,7 +15,6 @@ import org.bson.types.ObjectId;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.JobPersistenceException;
-import org.quartz.ObjectAlreadyExistsException;
 import org.quartz.impl.matchers.GroupMatcher;
 
 import java.util.*;
@@ -115,7 +113,7 @@ public class JobDao {
         return jobConverter.toJobDetail(doc);
     }
 
-    public ObjectId storeJobInMongo(JobDetail newJob, boolean replaceExisting) throws ObjectAlreadyExistsException {
+    public ObjectId storeJobInMongo(JobDetail newJob, boolean replaceExisting) throws JobPersistenceException {
         JobKey key = newJob.getKey();
 
         Bson keyDbo = toFilter(key);

--- a/src/test/groovy/com/novemberain/quartz/mongodb/JobDataConverterTest.groovy
+++ b/src/test/groovy/com/novemberain/quartz/mongodb/JobDataConverterTest.groovy
@@ -1,0 +1,144 @@
+package com.novemberain.quartz.mongodb
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import org.bson.Document
+import org.quartz.JobDataMap
+import org.quartz.JobPersistenceException
+import spock.lang.Specification
+
+class JobDataConverterTest extends Specification {
+
+    def converterBase64 = new JobDataConverter(true)
+    def converterPlain = new JobDataConverter(false)
+
+    def "empty job data doesn't modify the document"() {
+        given:
+        def emptyJobDataMap = new JobDataMap()
+        def doc = new Document()
+        when:
+        converterBase64.toDocument(emptyJobDataMap, doc);
+        then:
+        doc.size() == 0
+        when:
+        converterPlain.toDocument(emptyJobDataMap, doc);
+        then:
+        doc.size() == 0
+    }
+
+    def "document without job data doesn't modify job data map"() {
+        given:
+        def doc = new Document()
+        doc.put('foo', 'bar')
+        doc.put('num', 123)
+        def jobDataMap = new JobDataMap()
+        when:
+        def result1 = converterBase64.toJobData(doc, jobDataMap)
+        then:
+        !result1
+        jobDataMap.size() == 0
+        when:
+        def result2 = converterPlain.toJobData(doc, jobDataMap)
+        then:
+        !result2
+        jobDataMap.size() == 0
+    }
+
+    def "base64 encode works"() {
+        given:
+        def jobDataMap = createJobDataWithSerializableContent()
+        def doc = new Document()
+        when:
+        converterBase64.toDocument(jobDataMap, doc)
+        then:
+        doc.size() == 1
+        doc.get(Constants.JOB_DATA) == base64
+    }
+
+    def "base64 decode works"() {
+        given:
+        def doc = new Document()
+        doc.put(Constants.JOB_DATA, base64)
+        def jobDataMap = new JobDataMap()
+        when:
+        def result = converterBase64.toJobData(doc, jobDataMap)
+        then:
+        result
+        jobDataMap.getWrappedMap().size() == 2
+        jobDataMap.getWrappedMap() == createJobDataWithSerializableContent().getWrappedMap()
+    }
+
+    def "base64 decode fails"() {
+        given:
+        def doc = new Document()
+        doc.put(Constants.JOB_DATA, 'a' + base64)
+        def jobDataMap = new JobDataMap()
+        when:
+        converterBase64.toJobData(doc, jobDataMap)
+        then:
+        thrown(JobPersistenceException)
+    }
+
+    def "plain encode works"() {
+        given:
+        def jobDataMap = createJobDataWithSimpleContent()
+        def doc = new Document()
+        when:
+        converterPlain.toDocument(jobDataMap, doc)
+        then:
+        doc.size() == 1
+        doc.get(Constants.JOB_DATA_PLAIN) == createJobDataWithSimpleContent().getWrappedMap()
+    }
+
+    def "plain decode works"() {
+        given:
+        def doc = new Document()
+        doc.put(Constants.JOB_DATA_PLAIN, createJobDataWithSimpleContent().getWrappedMap())
+        def jobDataMap = new JobDataMap()
+        when:
+        def result = converterPlain.toJobData(doc, jobDataMap)
+        then:
+        result
+        jobDataMap.getWrappedMap().size() == 2
+        jobDataMap.getWrappedMap() == createJobDataWithSimpleContent().getWrappedMap()
+    }
+
+    def "plain decode falls back to base64"() {
+        given:
+        def doc = new Document()
+        doc.put(Constants.JOB_DATA, base64)
+        def jobDataMap = new JobDataMap()
+        when:
+        def result = converterPlain.toJobData(doc, jobDataMap)
+        then:
+        result
+        jobDataMap.getWrappedMap().size() == 2
+        jobDataMap.getWrappedMap() == createJobDataWithSerializableContent().getWrappedMap()
+    }
+
+    @ToString
+    @EqualsAndHashCode
+    static class Foo implements Serializable {
+        Bar bar;
+        String str;
+    }
+
+    @ToString
+    @EqualsAndHashCode
+    static class Bar implements Serializable {
+        String str;
+    }
+
+    def base64 = 'rO0ABXNyABFqYXZhLnV0aWwuSGFzaE1hcAUH2sHDFmDRAwACRgAKbG9hZEZhY3RvckkACXRocmVzaG9sZHhwP0AAAAAAAAx3CAAAABAAAAACdAADc3RydAADMTIzdAADZm9vc3IAN2NvbS5ub3ZlbWJlcmFpbi5xdWFydHoubW9uZ29kYi5Kb2JEYXRhQ29udmVydGVyVGVzdCRGb2+BqrZCje0rSgIAAkwAA2JhcnQAOUxjb20vbm92ZW1iZXJhaW4vcXVhcnR6L21vbmdvZGIvSm9iRGF0YUNvbnZlcnRlclRlc3QkQmFyO0wAA3N0cnQAEkxqYXZhL2xhbmcvU3RyaW5nO3hwc3IAN2NvbS5ub3ZlbWJlcmFpbi5xdWFydHoubW9uZ29kYi5Kb2JEYXRhQ29udmVydGVyVGVzdCRCYXL0UcKbkNKdkwIAAUwAA3N0cnEAfgAHeHB0AANhYmN0AANkZWZ4'
+
+    def createJobDataWithSerializableContent() {
+        def foo = new Foo(bar: new Bar(str: 'abc'), str: 'def')
+        def map = [foo: foo, str: '123']
+        new JobDataMap(map)
+    }
+
+    def createJobDataWithSimpleContent() {
+        def map = [foo: 'foo', bar: [one: 1, two: 2.0, list: ['a', 'b', 'c']]]
+        new JobDataMap(map)
+    }
+}

--- a/src/test/groovy/com/novemberain/quartz/mongodb/trigger/TriggerConverterTest.groovy
+++ b/src/test/groovy/com/novemberain/quartz/mongodb/trigger/TriggerConverterTest.groovy
@@ -1,5 +1,6 @@
 package com.novemberain.quartz.mongodb.trigger
 
+import com.novemberain.quartz.mongodb.JobDataConverter
 import com.novemberain.quartz.mongodb.dao.JobDao
 import com.novemberain.quartz.mongodb.util.Keys
 import org.bson.Document
@@ -15,7 +16,7 @@ class TriggerConverterTest extends Specification {
     def jobDao = Mock(JobDao)
 
     @Subject
-    def converter = new TriggerConverter(jobDao)
+    def converter = new TriggerConverter(jobDao, new JobDataConverter(true))
 
     def 'should return null when job of trigger is gone'() {
         given:


### PR DESCRIPTION
Storing Job Data as a `base64` should be optional (but default). Other option is to store directly as embedded document (if only simple types are used).