### PR TITLE
Make MongoConnector interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ idea {
 }
 dependencies {
     compile("org.quartz-scheduler:quartz:2.2.3")
-    compile("org.mongodb:mongo-java-driver:3.3.0")
+    compile("org.mongodb:mongodb-driver:3.3.0")
     compile("commons-codec:commons-codec:1.10")
     compile("org.slf4j:slf4j-api:1.7.21")
     provided("org.clojure:clojure:1.7.0")

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -9,25 +9,32 @@
  */
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.*;
-
+import com.mongodb.MongoClient;
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoException;
 import com.mongodb.client.MongoCollection;
-import com.novemberain.quartz.mongodb.util.*;
+import com.mongodb.client.MongoDatabase;
+import com.novemberain.quartz.mongodb.db.MongoConnector;
+import com.novemberain.quartz.mongodb.util.Keys;
 import org.bson.Document;
-import org.quartz.Calendar;
 import org.quartz.*;
 import org.quartz.Trigger.CompletedExecutionInstruction;
 import org.quartz.Trigger.TriggerState;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.spi.*;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 public class MongoDBJobStore implements JobStore, Constants {
 
     private MongoStoreAssembler assembler = new MongoStoreAssembler();
 
+    MongoConnector mongoConnector;
+    MongoDatabase mongoDatabase;
     MongoClient mongo;
     String collectionPrefix = "quartz_";
     String dbName;
@@ -57,6 +64,14 @@ public class MongoDBJobStore implements JobStore, Constants {
     int mongoOptionWriteConcernTimeoutMillis = 5000;
 
     public MongoDBJobStore() {
+    }
+
+    public MongoDBJobStore(final MongoConnector mongoConnector) {
+        this.mongoConnector = mongoConnector;
+    }
+
+    public MongoDBJobStore(final MongoDatabase mongoDatabase) {
+        this.mongoDatabase = mongoDatabase;
     }
 
     public MongoDBJobStore(final MongoClient mongo) {
@@ -112,7 +127,7 @@ public class MongoDBJobStore implements JobStore, Constants {
     @Override
     public void shutdown() {
         assembler.checkinExecutor.shutdown();
-        assembler.mongoConnector.shutdown();
+        assembler.mongoConnector.close();
     }
 
     @Override

--- a/src/main/java/com/novemberain/quartz/mongodb/db/ExternalMongoConnector.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/ExternalMongoConnector.java
@@ -1,0 +1,51 @@
+package com.novemberain.quartz.mongodb.db;
+
+import com.mongodb.MongoClient;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+
+/**
+ * The implementation of {@link MongoConnector} that doesn't own the lifecycle of {@link MongoClient}.
+ */
+public class ExternalMongoConnector implements MongoConnector {
+
+    private final WriteConcern writeConcern;
+    private final MongoDatabase database;
+
+    /**
+     * Constructs an instance of {@link ExternalMongoConnector}.
+     *
+     * @param writeConcern instance of {@link WriteConcern}. Each {@link MongoCollection} produced by
+     *                     {@link #getCollection(String)} will be configured with this write concern.
+     * @param database     {@link MongoDatabase} instance. Will be used to produce collections.
+     */
+    public ExternalMongoConnector(final WriteConcern writeConcern, final MongoDatabase database) {
+        this.database = database;
+        this.writeConcern = writeConcern;
+    }
+
+    /**
+     * Constructs an instance of {@link ExternalMongoConnector}.
+     *
+     * @param writeConcern instance of {@link WriteConcern}. Each {@link MongoCollection} produced by
+     *                     {@link #getCollection(String)} will be configured with this write concern.
+     * @param mongoClient  instance of {@link MongoClient}.
+     * @param dbName       name of the database that will be used to produce collections.
+     */
+    public ExternalMongoConnector(final WriteConcern writeConcern, final MongoClient mongoClient, final String dbName) {
+        this(writeConcern, mongoClient.getDatabase(dbName));
+    }
+
+    @Override
+    public MongoCollection<Document> getCollection(String collectionName) {
+        return database.getCollection(collectionName).withWriteConcern(writeConcern);
+    }
+
+    @Override
+    public void close() {
+        // we don't own the lifecycle of MongoClient, ignore.
+    }
+
+}

--- a/src/main/java/com/novemberain/quartz/mongodb/db/InternalMongoConnector.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/InternalMongoConnector.java
@@ -1,0 +1,113 @@
+package com.novemberain.quartz.mongodb.db;
+
+import com.mongodb.*;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.quartz.SchedulerConfigException;
+
+import java.util.List;
+
+/**
+ * The implementation of {@link MongoConnector} that owns the lifecycle of {@link MongoClient}.
+ */
+public class InternalMongoConnector implements MongoConnector {
+
+    private final WriteConcern writeConcern;
+    private final MongoClient mongoClient;
+    private final MongoDatabase database;
+
+    /**
+     * Constructs an instance of {@link InternalMongoConnector}.
+     *
+     * @param writeConcern instance of {@link WriteConcern}. Each {@link MongoCollection} produced by
+     *                     {@link #getCollection(String)} will be configured with this write concern.
+     * @param mongoClient  {@link MongoClient} that we just created.
+     * @param dbName       name of the database that will be used to produce collections.
+     */
+    private InternalMongoConnector(final WriteConcern writeConcern, final MongoClient mongoClient,
+                                   final String dbName) {
+        this.writeConcern = writeConcern;
+        this.mongoClient = mongoClient;
+        this.database = mongoClient.getDatabase(dbName);
+    }
+
+    /**
+     * Constructs an instance of {@link InternalMongoConnector} from connection URI.
+     *
+     * @param writeConcern instance of {@link WriteConcern}. Each {@link MongoCollection} produced by
+     *                     {@link #getCollection(String)} will be configured with this write concern.
+     * @param uri          MongoDB connection URI.
+     * @param dbName       name of the database that will be used to produce collections.
+     * @throws SchedulerConfigException if failed to create instance of MongoClient.
+     */
+    public InternalMongoConnector(final WriteConcern writeConcern, final String uri,
+                                  final String dbName) throws SchedulerConfigException {
+        this(writeConcern, createClient(uri), dbName);
+    }
+
+    /**
+     * Constructs an instance of {@link InternalMongoConnector}.
+     *
+     * @param writeConcern    instance of {@link WriteConcern}. Each {@link MongoCollection} produced by
+     *                        {@link #getCollection(String)} will be configured with this write concern.
+     * @param seeds           list of server addresses.
+     * @param credentialsList list of credentials used to authenticate all connections.
+     * @param options         default options.
+     * @param dbName          name of the database that will be used to produce collections.
+     * @throws SchedulerConfigException if failed to create instance of MongoClient.
+     */
+    public InternalMongoConnector(final WriteConcern writeConcern, final List<ServerAddress> seeds,
+                                  final List<MongoCredential> credentialsList, final MongoClientOptions options,
+                                  final String dbName) throws SchedulerConfigException {
+        this(writeConcern, createClient(seeds, credentialsList, options), dbName);
+    }
+
+    @Override
+    public MongoCollection<Document> getCollection(String collectionName) {
+        return database.getCollection(collectionName).withWriteConcern(writeConcern);
+    }
+
+    @Override
+    public void close() {
+        mongoClient.close();
+    }
+
+    /**
+     * Creates an instance of MongoClient from MongoClientURI wrapping exception.
+     */
+    private static MongoClient createClient(final MongoClientURI uri) throws SchedulerConfigException {
+        try {
+            return new MongoClient(uri);
+        } catch (final MongoException e) {
+            throw new SchedulerConfigException("MongoDB driver thrown an exception.", e);
+        }
+    }
+
+    /**
+     * Creates an instance of MongoClient from string URI wrapping exception.
+     */
+    private static MongoClient createClient(final String uri) throws SchedulerConfigException {
+        final MongoClientURI mongoUri;
+        try {
+            mongoUri = new MongoClientURI(uri);
+        } catch (final MongoException e) {
+            throw new SchedulerConfigException("Invalid mongo client uri.", e);
+        }
+        return createClient(mongoUri);
+    }
+
+    /**
+     * Creates an instance of MongoClient from server addresses, credentials and options wrapping exception.
+     */
+    private static MongoClient createClient(final List<ServerAddress> seeds,
+                                            final List<MongoCredential> credentialsList,
+                                            final MongoClientOptions options) throws SchedulerConfigException {
+        try {
+            return new MongoClient(seeds, credentialsList, options);
+        } catch (MongoException e) {
+            throw new SchedulerConfigException("MongoDB driver thrown an exception.", e);
+        }
+    }
+
+}

--- a/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnector.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnector.java
@@ -1,223 +1,30 @@
 package com.novemberain.quartz.mongodb.db;
 
-import com.mongodb.*;
-import com.mongodb.client.MongoDatabase;
-import org.quartz.SchedulerConfigException;
+import com.mongodb.MongoClient;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.io.Closeable;
 
 /**
- * The responsibility of this class is create a MongoClient with given parameters.
+ * Interface through which quartz-mongodb interacts with MongoDB.
  */
-public class MongoConnector {
+public interface MongoConnector extends Closeable {
 
-    private MongoClient mongo;
+    /**
+     * Quartz-mongodb will call this method to get the instance of {@link MongoCollection} for internal uses.
+     * The collection is expected to be fully configured with correct {@link WriteConcern}.
+     *
+     * @param collectionName collection name.
+     * @return instance of {@link MongoCollection}.
+     */
+    MongoCollection<Document> getCollection(final String collectionName);
 
-    private MongoConnector() {
-        // use the builder
-    }
-
-    public void shutdown() {
-        mongo.close();
-    }
-
-    public MongoDatabase selectDatabase(String dbName) {
-        return mongo.getDatabase(dbName);
-    }
-
-    public static MongoConnectorBuilder builder() {
-        return new MongoConnectorBuilder();
-    }
-
-    public static class MongoConnectorBuilder {
-        private MongoConnector connector = new MongoConnector();
-        private MongoClientOptions.Builder optionsBuilder = MongoClientOptions.builder();
-
-        private String mongoUri;
-        private String username;
-        private String password;
-        private String[] addresses;
-        private String dbName;
-        private String authDbName;
-        private int writeTimeout;
-
-        public MongoConnector build() throws SchedulerConfigException {
-            connect();
-            return connector;
-        }
-
-        public MongoConnectorBuilder withClient(MongoClient mongo) {
-            connector.mongo = mongo;
-            return this;
-        }
-
-        public MongoConnectorBuilder withUri(String mongoUri) {
-            this.mongoUri = mongoUri;
-            return this;
-        }
-
-        public MongoConnectorBuilder withCredentials(String username, String password) {
-            this.username = username;
-            this.password = password;
-            return this;
-        }
-
-        public MongoConnectorBuilder withAddresses(String[] addresses) {
-            this.addresses = addresses;
-            return this;
-        }
-
-        private void connect() throws SchedulerConfigException {
-            if (connector.mongo == null) {
-                initializeMongo();
-            } else {
-                if (mongoUri != null  || username != null || password != null || addresses != null){
-                    throw new SchedulerConfigException("Configure either a Mongo instance or MongoDB connection parameters.");
-                }
-            }
-        }
-
-        private void initializeMongo() throws SchedulerConfigException {
-            connector.mongo = connectToMongoDB();
-            if (connector.mongo == null) {
-                throw new SchedulerConfigException("Could not connect to MongoDB! Please check that quartz-mongodb configuration is correct.");
-            }
-            setWriteConcern();
-        }
-
-        private MongoClient connectToMongoDB() throws SchedulerConfigException {
-            if (mongoUri == null && (addresses == null || addresses.length == 0)) {
-                throw new SchedulerConfigException("At least one MongoDB address or a MongoDB URI must be specified .");
-            }
-
-            if (mongoUri != null) {
-                return connectToMongoDB(mongoUri);
-            }
-
-            return createClient();
-        }
-
-        private MongoClient createClient() throws SchedulerConfigException {
-            MongoClientOptions options = createOptions();
-            List<MongoCredential> credentials = createCredentials();
-            List<ServerAddress> serverAddresses = collectServerAddresses();
-            try {
-                return new MongoClient(serverAddresses, credentials, options);
-            } catch (MongoException e) {
-                throw new SchedulerConfigException("Could not connect to MongoDB", e);
-            }
-        }
-
-        private MongoClientOptions createOptions() {
-            return optionsBuilder.build();
-        }
-
-        private List<MongoCredential> createCredentials() {
-            List<MongoCredential> credentials = new ArrayList<MongoCredential>(1);
-            if (username != null) {
-                if (authDbName != null) {
-                    // authenticating to db which gives access to all other dbs (role - readWriteAnyDatabase)
-                    // by default in mongo it should be "admin"
-                    credentials.add(MongoCredential.createCredential(username, authDbName, password.toCharArray()));
-                } else {
-                    credentials.add(MongoCredential.createCredential(username, dbName, password.toCharArray()));
-                }
-            }
-            return credentials;
-        }
-
-        private List<ServerAddress> collectServerAddresses() {
-            List<ServerAddress> serverAddresses = new ArrayList<ServerAddress>();
-            for (String a : addresses) {
-                serverAddresses.add(new ServerAddress(a));
-            }
-            return serverAddresses;
-        }
-
-        private MongoClient connectToMongoDB(final String mongoUriAsString) throws SchedulerConfigException {
-            try {
-                return new MongoClient(new MongoClientURI(mongoUriAsString));
-            } catch (final MongoException e) {
-                throw new SchedulerConfigException("MongoDB driver thrown an exception", e);
-            }
-        }
-
-        private void setWriteConcern() {
-            // Use MAJORITY to make sure that writes (locks, updates, check-ins)
-            // are propagated to secondaries in a Replica Set. It allows us to
-            // have consistent state in case of failure of the primary.
-            //
-            // Since MongoDB 3.2, when MAJORITY is used and protocol version == 1
-            // for replica set, then Journaling in enabled by default for primary
-            // and secondaries.
-            WriteConcern writeConcern = WriteConcern.MAJORITY
-                    .withWTimeout(writeTimeout, TimeUnit.MILLISECONDS)
-                    .withJournal(true);
-            connector.mongo.setWriteConcern(writeConcern);
-        }
-
-        public MongoConnectorBuilder withAuthDatabaseName(String authDbName) {
-            this.authDbName = authDbName;
-            return this;
-        }
-
-        public MongoConnectorBuilder withDatabaseName(String dbName) {
-            this.dbName = dbName;
-            return this;
-        }
-
-        public MongoConnectorBuilder withMaxConnectionsPerHost(Integer maxConnectionsPerHost) {
-            if (maxConnectionsPerHost != null) {
-                optionsBuilder.connectionsPerHost(maxConnectionsPerHost);
-            }
-            return this;
-        }
-
-        public MongoConnectorBuilder withConnectTimeoutMillis(Integer connectTimeoutMillis) {
-            if (connectTimeoutMillis != null) {
-                optionsBuilder.connectTimeout(connectTimeoutMillis);
-            }
-            return this;
-        }
-
-        public MongoConnectorBuilder withSocketTimeoutMillis(Integer socketTimeoutMillis) {
-            if (socketTimeoutMillis != null) {
-                optionsBuilder.socketTimeout(socketTimeoutMillis);
-            }
-            return this;
-        }
-
-        public MongoConnectorBuilder withSocketKeepAlive(Boolean socketKeepAlive) {
-            if (socketKeepAlive != null) {
-                optionsBuilder.socketKeepAlive(socketKeepAlive);
-            }
-            return this;
-        }
-
-        public MongoConnectorBuilder withThreadsAllowedToBlockForConnectionMultiplier(
-                Integer threadsAllowedToBlockForConnectionMultiplier) {
-            if (threadsAllowedToBlockForConnectionMultiplier != null) {
-                optionsBuilder.threadsAllowedToBlockForConnectionMultiplier(
-                        threadsAllowedToBlockForConnectionMultiplier);
-            }
-            return this;
-        }
-
-        public MongoConnectorBuilder withSSL(Boolean enableSSL, Boolean sslInvalidHostNameAllowed) {
-            if (enableSSL != null) {
-                optionsBuilder.sslEnabled(enableSSL);
-                if (sslInvalidHostNameAllowed != null) {
-                    optionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
-                }
-            }
-            return this;
-        }
-
-        public MongoConnectorBuilder withWriteTimeout(int writeTimeout) {
-            this.writeTimeout = writeTimeout;
-            return this;
-        }
-    }
+    /**
+     * Quartz-mongodb will call this method when shutting down.
+     * Implementation can close {@link MongoClient} here.
+     */
+    @Override
+    void close();
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
@@ -1,0 +1,295 @@
+package com.novemberain.quartz.mongodb.db;
+
+import com.mongodb.*;
+import com.mongodb.client.MongoDatabase;
+import org.quartz.SchedulerConfigException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Builder for {@link MongoConnector}.
+ */
+public class MongoConnectorBuilder {
+
+    private static final String PARAM_NOT_ALLOWED = "'%s' parameter is not allowed. %s";
+    private MongoConnector connector;
+    private Integer writeTimeout;
+    private MongoDatabase database;
+    private MongoClient client;
+    private String dbName;
+    private String uri;
+    private String[] addresses;
+    private String username;
+    private String password;
+    private String authDbName;
+    private Integer maxConnectionsPerHost;
+    private Integer connectTimeoutMillis;
+    private Integer socketTimeoutMillis;
+    private Boolean socketKeepAlive;
+    private Integer threadsAllowedToBlockForConnectionMultiplier;
+    private Boolean enableSSL;
+    private Boolean sslInvalidHostNameAllowed;
+
+    /**
+     * Use {@link #builder()}.
+     */
+    private MongoConnectorBuilder() {
+    }
+
+    /**
+     * Creates a builder.
+     *
+     * @return new builder instance.
+     */
+    public static MongoConnectorBuilder builder() {
+        return new MongoConnectorBuilder();
+    }
+
+    /**
+     * Builds MongoConnector from current settings.
+     *
+     * @return an instance of {@link MongoConnector}.
+     * @throws SchedulerConfigException if builder was in invalid state.
+     */
+    public MongoConnector build() throws SchedulerConfigException {
+        if (connector != null) {
+            // User implemented MongoConnector himself, highest priority.
+            validateForConnector();
+            return connector;
+        }
+
+        // Options below require WriteConcern
+        final WriteConcern writeConcern = createWriteConcern();
+
+        if (database != null) {
+            // User passed MongoDatabase instance.
+            validateForDatabase();
+            return new ExternalMongoConnector(writeConcern, database);
+        }
+
+        // Options below require database name
+        checkNotNull(dbName, "'Database name' parameter is required.");
+
+        if (client != null) {
+            // User passed MongoClient instance.
+            validateForClient();
+            return new ExternalMongoConnector(writeConcern, client, dbName);
+        }
+
+        if (uri != null) {
+            // User passed URI.
+            validateForUri();
+            return new InternalMongoConnector(writeConcern, uri, dbName);
+        }
+
+        checkNotNull(addresses, "At least one MongoDB address or a MongoDB URI must be specified.");
+        final List<ServerAddress> serverAddresses = collectServerAddresses();
+        final List<MongoCredential> credentials = createCredentials();
+        final MongoClientOptions options = createOptions();
+        return new InternalMongoConnector(writeConcern, serverAddresses, credentials, options, dbName);
+    }
+
+    private List<ServerAddress> collectServerAddresses() {
+        final List<ServerAddress> serverAddresses = new ArrayList<>(addresses.length);
+        for (final String address : addresses) {
+            serverAddresses.add(new ServerAddress(address));
+        }
+        return serverAddresses;
+    }
+
+    private List<MongoCredential> createCredentials() {
+        if (username != null) {
+            final MongoCredential cred;
+            if (authDbName != null) {
+                // authenticating to db which gives access to all other dbs (role - readWriteAnyDatabase)
+                // by default in mongo it should be "admin"
+                cred = MongoCredential.createCredential(username, authDbName, password.toCharArray());
+            } else {
+                cred = MongoCredential.createCredential(username, dbName, password.toCharArray());
+            }
+            return Collections.singletonList(cred);
+        }
+        return Collections.emptyList();
+    }
+
+    private MongoClientOptions createOptions() {
+        final MongoClientOptions.Builder optionsBuilder = MongoClientOptions.builder();
+        if (maxConnectionsPerHost != null) {
+            optionsBuilder.connectionsPerHost(maxConnectionsPerHost);
+        }
+        if (connectTimeoutMillis != null) {
+            optionsBuilder.connectTimeout(connectTimeoutMillis);
+        }
+        if (socketTimeoutMillis != null) {
+            optionsBuilder.socketTimeout(socketTimeoutMillis);
+        }
+        if (socketKeepAlive != null) {
+            optionsBuilder.socketKeepAlive(socketKeepAlive);
+        }
+        if (threadsAllowedToBlockForConnectionMultiplier != null) {
+            optionsBuilder.threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier);
+        }
+        if (enableSSL != null) {
+            optionsBuilder.sslEnabled(enableSSL);
+            if (sslInvalidHostNameAllowed != null) {
+                optionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
+            }
+        }
+        return optionsBuilder.build();
+    }
+
+    private WriteConcern createWriteConcern() throws SchedulerConfigException {
+        // Use MAJORITY to make sure that writes (locks, updates, check-ins)
+        // are propagated to secondaries in a Replica Set. It allows us to
+        // have consistent state in case of failure of the primary.
+        //
+        // Since MongoDB 3.2, when MAJORITY is used and protocol version == 1
+        // for replica set, then Journaling in enabled by default for primary
+        // and secondaries.
+        checkNotNull(writeTimeout, "Write timeout is expected.");
+        return WriteConcern.MAJORITY.withWTimeout(writeTimeout, TimeUnit.MILLISECONDS)
+                .withJournal(true);
+    }
+
+    private void validateForConnector() throws SchedulerConfigException {
+        final String suffix = "'Connector' parameter is used.";
+        checkIsNull(database, paramNotAllowed("Database", suffix));
+        checkIsNull(client, paramNotAllowed("Client", suffix));
+        checkIsNull(dbName, paramNotAllowed("Database name", suffix));
+        checkIsNull(uri, paramNotAllowed("URI", suffix));
+        checkServersCredsOptionsAreNull(suffix);
+    }
+
+    private void validateForDatabase() throws SchedulerConfigException {
+        final String suffix = "'Database' parameter is used.";
+        checkIsNull(client, paramNotAllowed("Client", suffix));
+        checkIsNull(dbName, paramNotAllowed("Database name", suffix));
+        checkIsNull(uri, paramNotAllowed("URI", suffix));
+        checkServersCredsOptionsAreNull(suffix);
+    }
+
+    private void validateForClient() throws SchedulerConfigException {
+        final String suffix = "'Client' parameter is used.";
+        checkIsNull(uri, paramNotAllowed("URI", suffix));
+        checkServersCredsOptionsAreNull(suffix);
+    }
+
+    private void validateForUri() throws SchedulerConfigException {
+        checkServersCredsOptionsAreNull("'URI' parameter is used.");
+    }
+
+    private static <T> T checkNotNull(final T reference, final String message) throws SchedulerConfigException {
+        if (reference == null) {
+            throw new SchedulerConfigException(message);
+        }
+        return reference;
+    }
+
+    private static void checkIsNull(final Object reference, final String message) throws SchedulerConfigException {
+        if (reference != null) {
+            throw new SchedulerConfigException(message);
+        }
+    }
+
+    private void checkServersCredsOptionsAreNull(final String suffix) throws SchedulerConfigException {
+        checkIsNull(addresses, paramNotAllowed("Addresses array", suffix));
+        checkIsNull(username, paramNotAllowed("Username", suffix));
+        checkIsNull(password, paramNotAllowed("Password", suffix));
+        checkIsNull(authDbName, paramNotAllowed("Auth database name", suffix));
+        checkIsNull(maxConnectionsPerHost, paramNotAllowed("Max connections per host", suffix));
+        checkIsNull(connectTimeoutMillis, paramNotAllowed("Connect timeout millis", suffix));
+        checkIsNull(socketTimeoutMillis, paramNotAllowed("Socket timeout millis", suffix));
+        checkIsNull(socketKeepAlive, paramNotAllowed("Socket keepAlive", suffix));
+        checkIsNull(threadsAllowedToBlockForConnectionMultiplier,
+                paramNotAllowed("Threads allowed to block for connection multiplier", suffix));
+        checkIsNull(enableSSL, paramNotAllowed("Enable ssl", suffix));
+        checkIsNull(sslInvalidHostNameAllowed, paramNotAllowed("SSL invalid hostname allowed", suffix));
+    }
+
+    private static String paramNotAllowed(final String paramName, final String suffix) {
+        return String.format(PARAM_NOT_ALLOWED, paramName, suffix);
+    }
+
+    // mutators below
+
+    public MongoConnectorBuilder withConnector(final MongoConnector connector) {
+        this.connector = connector;
+        return this;
+    }
+
+    public MongoConnectorBuilder withWriteTimeout(int writeTimeout) {
+        this.writeTimeout = writeTimeout;
+        return this;
+    }
+
+    public MongoConnectorBuilder withDatabase(final MongoDatabase database) {
+        this.database = database;
+        return this;
+    }
+
+    public MongoConnectorBuilder withClient(final MongoClient client) {
+        this.client = client;
+        return this;
+    }
+
+    public MongoConnectorBuilder withDatabaseName(String dbName) {
+        this.dbName = dbName;
+        return this;
+    }
+
+    public MongoConnectorBuilder withUri(final String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public MongoConnectorBuilder withAddresses(final String[] addresses) {
+        this.addresses = addresses;
+        return this;
+    }
+
+    public MongoConnectorBuilder withCredentials(final String username, final String password) {
+        this.username = username;
+        this.password = password;
+        return this;
+    }
+
+    public MongoConnectorBuilder withAuthDatabaseName(String authDbName) {
+        this.authDbName = authDbName;
+        return this;
+    }
+
+    public MongoConnectorBuilder withMaxConnectionsPerHost(final Integer maxConnectionsPerHost) {
+        this.maxConnectionsPerHost = maxConnectionsPerHost;
+        return this;
+    }
+
+    public MongoConnectorBuilder withConnectTimeoutMillis(final Integer connectTimeoutMillis) {
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        return this;
+    }
+
+    public MongoConnectorBuilder withSocketTimeoutMillis(final Integer socketTimeoutMillis) {
+        this.socketTimeoutMillis = socketTimeoutMillis;
+        return this;
+    }
+
+    public MongoConnectorBuilder withSocketKeepAlive(final Boolean socketKeepAlive) {
+        this.socketKeepAlive = socketKeepAlive;
+        return this;
+    }
+
+    public MongoConnectorBuilder withThreadsAllowedToBlockForConnectionMultiplier(
+            final Integer threadsAllowedToBlockForConnectionMultiplier) {
+        this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
+        return this;
+    }
+
+    public MongoConnectorBuilder withSSL(final Boolean enableSSL, final Boolean sslInvalidHostNameAllowed) {
+        this.enableSSL = enableSSL;
+        this.sslInvalidHostNameAllowed = sslInvalidHostNameAllowed;
+        return this;
+    }
+}


### PR DESCRIPTION
Reworked the way how quartz-mongodb accesses mongodb. It is now through the MongoConnector interface. Support two implementations out of the box: the one that owns the lifecycle of MongoClient (creates and closes) and another that just uses what user provided.