### PR TITLE
Set ERROR state for trigger without existing job.

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/LockManager.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/LockManager.java
@@ -90,7 +90,7 @@ public class LockManager {
                         key, existingLock.getDate(Constants.LOCK_TIME));
             }
         } else {
-            log.warn("Error retrieving expired lock from the database. Maybe it was deleted");
+            log.warn("Error retrieving expired lock from the database for trigger {}. Maybe it was deleted", key);
         }
         return false;
     }

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoStoreAssembler.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoStoreAssembler.java
@@ -49,7 +49,7 @@ public class MongoStoreAssembler {
 
         jobDao = createJobDao(jobStore, loadHelper, jobDataConverter);
 
-        triggerConverter = new TriggerConverter(jobDao, jobDataConverter);
+        triggerConverter = new TriggerConverter(jobDao, jobDataConverter, triggerDao);
 
         triggerDao = createTriggerDao(jobStore);
         calendarDao = createCalendarDao(jobStore);


### PR DESCRIPTION
Similar to what we can see here:
https://github.com/quartz-scheduler/quartz/blob/5cc9a44ab96ad5a3591d9d77472ff6620d85456c/quartz-core/src/main/java/org/quartz/impl/jdbcjobstore/JobStoreSupport.java#L2822

Plus added extra logging, because people can not be aware of such situations.