### PR TITLE
Support MongoClient initialization with a URI

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/db/InternalMongoConnector.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/InternalMongoConnector.java
@@ -22,6 +22,19 @@ public class InternalMongoConnector implements MongoConnector {
      *
      * @param writeConcern instance of {@link WriteConcern}. Each {@link MongoCollection} produced by
      *                     {@link #getCollection(String)} will be configured with this write concern.
+     * @param mongoClientURI  {@link MongoClientURI} that we just created.
+     */
+    public InternalMongoConnector(final WriteConcern writeConcern, final MongoClientURI mongoClientURI) {
+        this.writeConcern = writeConcern;
+        this.mongoClient = new MongoClient(mongoClientURI);
+        this.database = this.mongoClient.getDatabase(mongoClientURI.getDatabase());
+    }
+
+    /**
+     * Constructs an instance of {@link InternalMongoConnector}.
+     *
+     * @param writeConcern instance of {@link WriteConcern}. Each {@link MongoCollection} produced by
+     *                     {@link #getCollection(String)} will be configured with this write concern.
      * @param mongoClient  {@link MongoClient} that we just created.
      * @param dbName       name of the database that will be used to produce collections.
      */

--- a/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
@@ -70,6 +70,16 @@ public class MongoConnectorBuilder {
             return new ExternalMongoConnector(writeConcern, database);
         }
 
+        if (uri != null) {
+            // User passed URI.
+            validateForUri();
+            MongoClientURI mongoUri = new MongoClientURI(uri);
+            if(dbName == null){
+                dbName = mongoUri.getDatabase();
+            }
+            return new InternalMongoConnector(writeConcern, mongoUri);
+        }
+
         // Options below require database name
         checkNotNull(dbName, "'Database name' parameter is required.");
 
@@ -77,12 +87,6 @@ public class MongoConnectorBuilder {
             // User passed MongoClient instance.
             validateForClient();
             return new ExternalMongoConnector(writeConcern, client, dbName);
-        }
-
-        if (uri != null) {
-            // User passed URI.
-            validateForUri();
-            return new InternalMongoConnector(writeConcern, uri, dbName);
         }
 
         checkNotNull(addresses, "At least one MongoDB address or a MongoDB URI must be specified.");


### PR DESCRIPTION
Mongo configuration : Mongodb URI connection [Doc](https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html#the-url-connection-format)

```
org.quartz.jobStore.mongoUri=mongodb://username:password@host_1:27017,host_2:27017,host_3:27017/database_name?replicaSet=name_replicaset
```
