### PR TITLE
lower the log to debug for actions that are triggered every couple of seconds

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/cluster/CheckinTask.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/cluster/CheckinTask.java
@@ -27,7 +27,7 @@ public class CheckinTask implements Runnable {
 
     @Override
     public void run() {
-        log.info("Node {}:{} checks-in.", schedulerDao.schedulerName, schedulerDao.instanceId);
+        log.debug("Node {}:{} checks-in.", schedulerDao.schedulerName, schedulerDao.instanceId);
         try {
             schedulerDao.checkIn();
         } catch (MongoException e) {

--- a/src/main/java/com/novemberain/quartz/mongodb/dao/TriggerDao.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/dao/TriggerDao.java
@@ -73,7 +73,7 @@ public class TriggerDao {
     public FindIterable<Document> findEligibleToRun(Date noLaterThanDate) {
         Bson query = createNextTriggerQuery(noLaterThanDate);
         if (log.isInfoEnabled()) {
-            log.info("Found {} triggers which are eligible to be run.", getCount(query));
+            log.debug("Found {} triggers which are eligible to be run.", getCount(query));
         }
         return triggerCollection.find(query).sort(ascending(Constants.TRIGGER_NEXT_FIRE_TIME));
     }


### PR DESCRIPTION
These methods are invoked very often by quartz, therefore a debug level fits more for these lines.