### PR TITLE
Fix for #161: allow MongoDB/SSL connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     compile("org.quartz-scheduler:quartz:2.3.2")
     compile("org.mongodb:mongodb-driver:3.9.1")
     compile("commons-codec:commons-codec:1.10")
+    compile("org.apache.commons:commons-lang3:3.8")
+    compile("org.apache.httpcomponents:httpcore:4.4.10")
     compile("org.slf4j:slf4j-api:1.7.21")
 
     compileOnly("org.clojure:clojure:1.10.0")

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -651,6 +651,7 @@ public class MongoDBJobStore implements JobStore, Constants {
 
     public void setMongoOptionKeyStoreType(String keyStoreType) {
         this.mongoOptionKeyStoreType = keyStoreType;
+    }
 
     public void setMongoOptionWriteConcernW(String mongoOptionWriteConcernW) {
         this.mongoOptionWriteConcernW = mongoOptionWriteConcernW;

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -64,6 +64,12 @@ public class MongoDBJobStore implements JobStore, Constants {
     Integer mongoOptionThreadsAllowedToBlockForConnectionMultiplier;
     Boolean mongoOptionEnableSSL;
     Boolean mongoOptionSslInvalidHostNameAllowed;
+    String mongoOptionTrustStorePath;
+    String mongoOptionTrustStorePassword;
+    String mongoOptionTrustStoreType;
+    String mongoOptionKeyStorePath;
+    String mongoOptionKeyStorePassword;
+    String mongoOptionKeyStoreType;
 
     int mongoOptionWriteConcernTimeoutMillis = 5000;
     public static final String PROPERTIES_FILE_NAME = "quartz.properties";
@@ -620,6 +626,30 @@ public class MongoDBJobStore implements JobStore, Constants {
 
     public void setMongoOptionSslInvalidHostNameAllowed(boolean sslInvalidHostNameAllowed) {
         this.mongoOptionSslInvalidHostNameAllowed = sslInvalidHostNameAllowed;
+    }
+
+    public void setMongoOptionTrustStorePath(String trustStorePath) {
+        this.mongoOptionTrustStorePath = trustStorePath;
+    }
+
+    public void setMongoOptionTrustStorePassword(String trustStorePassword) {
+        this.mongoOptionTrustStorePassword = trustStorePassword;
+    }
+
+    public void setMongoOptionTrustStoreType(String trustStoreType) {
+        this.mongoOptionTrustStoreType = trustStoreType;
+    }
+
+    public void setMongoOptionKeyStorePath(String keyStorePath) {
+        this.mongoOptionKeyStorePath = keyStorePath;
+    }
+
+    public void setMongoOptionKeyStorePassword(String keyStorePassword) {
+        this.mongoOptionKeyStorePassword = keyStorePassword;
+    }
+
+    public void setMongoOptionKeyStoreType(String keyStoreType) {
+        this.mongoOptionKeyStoreType = keyStoreType;
     }
 
     public void setMongoOptionWriteConcernTimeoutMillis(int writeConcernTimeoutMillis) {

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoStoreAssembler.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoStoreAssembler.java
@@ -146,6 +146,8 @@ public class MongoStoreAssembler {
                 .withThreadsAllowedToBlockForConnectionMultiplier(
                         jobStore.mongoOptionThreadsAllowedToBlockForConnectionMultiplier)
                 .withSSL(jobStore.mongoOptionEnableSSL, jobStore.mongoOptionSslInvalidHostNameAllowed)
+                .withTrustStore(jobStore.mongoOptionTrustStorePath, jobStore.mongoOptionTrustStorePassword, jobStore.mongoOptionTrustStoreType)
+                .withKeyStore(jobStore.mongoOptionKeyStorePath, jobStore.mongoOptionKeyStorePassword, jobStore.mongoOptionKeyStoreType)
                 .withWriteTimeout(jobStore.mongoOptionWriteConcernTimeoutMillis)
                 .build();
     }

--- a/src/main/java/com/novemberain/quartz/mongodb/db/InternalMongoConnector.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/InternalMongoConnector.java
@@ -44,7 +44,22 @@ public class InternalMongoConnector implements MongoConnector {
      */
     public InternalMongoConnector(final WriteConcern writeConcern, final String uri,
                                   final String dbName) throws SchedulerConfigException {
-        this(writeConcern, createClient(uri), dbName);
+        this(writeConcern, uri, dbName, null);
+    }
+
+    /**
+     * Constructs an instance of {@link InternalMongoConnector} from connection URI and option builder.
+     *
+     * @param writeConcern instance of {@link WriteConcern}. Each {@link MongoCollection} produced by
+     *                     {@link #getCollection(String)} will be configured with this write concern.
+     * @param uri          MongoDB connection URI.
+     * @param dbName       name of the database that will be used to produce collections.
+     * @param optionBuilder      default option builder.
+     * @throws SchedulerConfigException if failed to create instance of MongoClient.
+     */
+    public InternalMongoConnector(final WriteConcern writeConcern, final String uri,
+                                  final String dbName, MongoClientOptions.Builder optionBuilder) throws SchedulerConfigException {
+        this(writeConcern, createClient(uri, optionBuilder), dbName);
     }
 
     /**
@@ -86,12 +101,12 @@ public class InternalMongoConnector implements MongoConnector {
     }
 
     /**
-     * Creates an instance of MongoClient from string URI wrapping exception.
+     * Creates an instance of MongoClient from string URI and option builder wrapping exception.
      */
-    private static MongoClient createClient(final String uri) throws SchedulerConfigException {
+    private static MongoClient createClient(final String uri, MongoClientOptions.Builder optionBuilder) throws SchedulerConfigException {
         final MongoClientURI mongoUri;
         try {
-            mongoUri = new MongoClientURI(uri);
+            mongoUri = optionBuilder == null ? new MongoClientURI(uri) : new MongoClientURI(uri, optionBuilder);
         } catch (final MongoException e) {
             throw new SchedulerConfigException("Invalid mongo client uri.", e);
         }

--- a/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+
 /**
  * Builder for {@link MongoConnector}.
  */
@@ -33,6 +36,13 @@ public class MongoConnectorBuilder {
     private Integer threadsAllowedToBlockForConnectionMultiplier;
     private Boolean enableSSL;
     private Boolean sslInvalidHostNameAllowed;
+    private String trustStorePath;
+    private String trustStorePassword;
+    private String trustStoreType;
+    private String keyStorePath;
+    private String keyStorePassword;
+    private String keyStoreType;
+    private SSLContextFactory sslContextFactory = new SSLContextFactory();
 
     /**
      * Use {@link #builder()}.
@@ -80,17 +90,17 @@ public class MongoConnectorBuilder {
             return new ExternalMongoConnector(writeConcern, client, dbName);
         }
 
+        final MongoClientOptions.Builder optionsBuilder = createOptionBuilder();
         if (uri != null) {
             // User passed URI.
             validateForUri();
-            return new InternalMongoConnector(writeConcern, uri, dbName);
+            return new InternalMongoConnector(writeConcern, uri, dbName, optionsBuilder);
         }
 
         checkNotNull(addresses, "At least one MongoDB address or a MongoDB URI must be specified.");
         final List<ServerAddress> serverAddresses = collectServerAddresses();
         final Optional<MongoCredential> credentials = createCredentials();
-        final MongoClientOptions options = createOptions();
-        return new InternalMongoConnector(writeConcern, serverAddresses, credentials, options, dbName);
+        return new InternalMongoConnector(writeConcern, serverAddresses, credentials, optionsBuilder.build(), dbName);
     }
 
     private List<ServerAddress> collectServerAddresses() {
@@ -116,7 +126,7 @@ public class MongoConnectorBuilder {
         return Optional.empty();
     }
 
-    private MongoClientOptions createOptions() {
+    private MongoClientOptions.Builder createOptionBuilder() throws SchedulerConfigException {
         final MongoClientOptions.Builder optionsBuilder = MongoClientOptions.builder();
         if (maxConnectionsPerHost != null) {
             optionsBuilder.connectionsPerHost(maxConnectionsPerHost);
@@ -134,13 +144,31 @@ public class MongoConnectorBuilder {
         if (threadsAllowedToBlockForConnectionMultiplier != null) {
             optionsBuilder.threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier);
         }
-        if (enableSSL != null) {
-            optionsBuilder.sslEnabled(enableSSL);
-            if (sslInvalidHostNameAllowed != null) {
-                optionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
+        hanldeSSLContext(optionsBuilder);
+        return optionsBuilder;
+    }
+
+    private void hanldeSSLContext(MongoClientOptions.Builder optionsBuilder) throws SchedulerConfigException {
+        try {
+            SSLContext sslContext = sslContextFactory.getSSLContext(trustStorePath, trustStorePassword, trustStoreType,
+                    keyStorePath, keyStorePassword, keyStoreType);
+            if (sslContext == null) {
+                if (enableSSL != null) {
+                    optionsBuilder.sslEnabled(enableSSL);
+                    if (sslInvalidHostNameAllowed != null) {
+                        optionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
+                    }
+                }
+            } else {
+                optionsBuilder.sslEnabled(true);
+                if (sslInvalidHostNameAllowed != null) {
+                    optionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
+                }
+                optionsBuilder.sslContext(sslContext);
             }
+        } catch (SSLException e) {
+            throw new SchedulerConfigException("Cannot setup SSL context", e);
         }
-        return optionsBuilder.build();
     }
 
     private WriteConcern createWriteConcern() throws SchedulerConfigException {
@@ -162,7 +190,8 @@ public class MongoConnectorBuilder {
         checkIsNull(client, paramNotAllowed("Client", suffix));
         checkIsNull(dbName, paramNotAllowed("Database name", suffix));
         checkIsNull(uri, paramNotAllowed("URI", suffix));
-        checkServersCredsOptionsAreNull(suffix);
+        checkServerPropertiesAreNull(suffix);
+        checkConnectionOptionsAreNull(suffix);
     }
 
     private void validateForDatabase() throws SchedulerConfigException {
@@ -170,17 +199,19 @@ public class MongoConnectorBuilder {
         checkIsNull(client, paramNotAllowed("Client", suffix));
         checkIsNull(dbName, paramNotAllowed("Database name", suffix));
         checkIsNull(uri, paramNotAllowed("URI", suffix));
-        checkServersCredsOptionsAreNull(suffix);
+        checkServerPropertiesAreNull(suffix);
+        checkConnectionOptionsAreNull(suffix);
     }
 
     private void validateForClient() throws SchedulerConfigException {
         final String suffix = "'Client' parameter is used.";
         checkIsNull(uri, paramNotAllowed("URI", suffix));
-        checkServersCredsOptionsAreNull(suffix);
+        checkServerPropertiesAreNull(suffix);
+        checkConnectionOptionsAreNull(suffix);
     }
 
     private void validateForUri() throws SchedulerConfigException {
-        checkServersCredsOptionsAreNull("'URI' parameter is used.");
+        checkServerPropertiesAreNull("'URI' parameter is used.");
     }
 
     private static <T> T checkNotNull(final T reference, final String message) throws SchedulerConfigException {
@@ -196,11 +227,14 @@ public class MongoConnectorBuilder {
         }
     }
 
-    private void checkServersCredsOptionsAreNull(final String suffix) throws SchedulerConfigException {
+    private void checkServerPropertiesAreNull(final String suffix) throws SchedulerConfigException {
         checkIsNull(addresses, paramNotAllowed("Addresses array", suffix));
         checkIsNull(username, paramNotAllowed("Username", suffix));
         checkIsNull(password, paramNotAllowed("Password", suffix));
         checkIsNull(authDbName, paramNotAllowed("Auth database name", suffix));
+    }
+
+    private void checkConnectionOptionsAreNull(final String suffix) throws SchedulerConfigException {
         checkIsNull(maxConnectionsPerHost, paramNotAllowed("Max connections per host", suffix));
         checkIsNull(connectTimeoutMillis, paramNotAllowed("Connect timeout millis", suffix));
         checkIsNull(socketTimeoutMillis, paramNotAllowed("Socket timeout millis", suffix));
@@ -209,6 +243,12 @@ public class MongoConnectorBuilder {
                 paramNotAllowed("Threads allowed to block for connection multiplier", suffix));
         checkIsNull(enableSSL, paramNotAllowed("Enable ssl", suffix));
         checkIsNull(sslInvalidHostNameAllowed, paramNotAllowed("SSL invalid hostname allowed", suffix));
+        checkIsNull(trustStorePath, paramNotAllowed("TrustStore path", suffix));
+        checkIsNull(trustStorePassword, paramNotAllowed("TrustStore password", suffix));
+        checkIsNull(trustStoreType, paramNotAllowed("TrustStore type", suffix));
+        checkIsNull(keyStorePath, paramNotAllowed("KeyStore path", suffix));
+        checkIsNull(keyStorePassword, paramNotAllowed("KeyStore password", suffix));
+        checkIsNull(keyStoreType, paramNotAllowed("KeyStore type", suffix));
     }
 
     private static String paramNotAllowed(final String paramName, final String suffix) {
@@ -294,4 +334,19 @@ public class MongoConnectorBuilder {
         this.sslInvalidHostNameAllowed = sslInvalidHostNameAllowed;
         return this;
     }
+
+    public MongoConnectorBuilder withTrustStore(String trustStorePath, String trustStorePassword, String trustStoreType) {
+        this.trustStorePath = trustStorePath;
+        this.trustStorePassword = trustStorePassword;
+        this.trustStoreType = trustStoreType;
+        return this;
+    }
+
+    public MongoConnectorBuilder withKeyStore(String keyStorePath, String keyStorePassword, String keyStoreType) {
+        this.keyStorePath = keyStorePath;
+        this.keyStorePassword = keyStorePassword;
+        this.keyStoreType = keyStoreType;
+        return this;
+    }
+
 }

--- a/src/main/java/com/novemberain/quartz/mongodb/db/SSLContextFactory.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/SSLContextFactory.java
@@ -1,0 +1,57 @@
+package com.novemberain.quartz.mongodb.db;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+
+/**
+ * Allows to get an {@link SSLContext} from a Java truststore and keystore.
+ */
+public class SSLContextFactory {
+
+    public SSLContext getSSLContext(String trustStorePath, String trustStorePassword, String trustStoreType,
+            String keyStorePath, String keyStorePassword, String keyStoreType) throws SSLException {
+        try {
+            KeyStore trustStore = loadKeyStore(trustStorePath, trustStorePassword, trustStoreType);
+            KeyStore keyStore = loadKeyStore(keyStorePath, keyStorePassword, keyStoreType);
+            if (trustStore == null && keyStore == null) {
+                return null;
+            }
+            SSLContextBuilder sslContextBuilder = SSLContexts.custom();
+            if (trustStore != null) {
+                sslContextBuilder.loadTrustMaterial(trustStore, null);
+            }
+            if (keyStore != null) {
+                sslContextBuilder.loadKeyMaterial(keyStore,
+                        StringUtils.isBlank(keyStorePassword) ? null : keyStorePassword.toCharArray());
+            }
+            return sslContextBuilder.build();
+        } catch (GeneralSecurityException | IOException e) {
+            throw new SSLException("Cannot setup SSL context", e);
+        }
+    }
+
+    private KeyStore loadKeyStore(String path, String password, String type)
+            throws GeneralSecurityException, IOException {
+        if (StringUtils.isBlank(path)) {
+            return null;
+        }
+        KeyStore keyStore = KeyStore.getInstance(StringUtils.defaultIfBlank(type, KeyStore.getDefaultType()));
+        char[] passwordChars = StringUtils.isBlank(password) ? null : password.toCharArray();
+        try (InputStream is = Files.newInputStream(Paths.get(path))) {
+            keyStore.load(is, passwordChars);
+        }
+        return keyStore;
+    }
+
+}


### PR DESCRIPTION
Hi, this is a fix for #161.

It allows to use a Java keystore and truststore by taking into account the following quartz properties:
```
org.quartz.jobStore.mongoOptionEnableSSL
org.quartz.jobStore.mongoOptionTrustStorePath
org.quartz.jobStore.mongoOptionTrustStorePassword
org.quartz.jobStore.mongoOptionTrustStoreType
org.quartz.jobStore.mongoOptionKeyStorePath
org.quartz.jobStore.mongoOptionKeyStorePassword
org.quartz.jobStore.mongoOptionKeyStoreType
```
I didn't add any tests but `./gradlew assemble` and `./gradlew check` pass.

Hope it's OK!