### PR TITLE
Mark job as expired based on checkIns

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/util/ExpiryCalculator.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/util/ExpiryCalculator.java
@@ -27,7 +27,7 @@ public class ExpiryCalculator {
     }
 
     public boolean isJobLockExpired(Document lock) {
-        return isLockExpired(lock, jobTimeoutMillis);
+        return isLockExpired(lock, jobTimeoutMillis) || hasDefunctScheduler(lock);
     }
 
     public boolean isTriggerLockExpired(Document lock) {
@@ -42,6 +42,11 @@ public class ExpiryCalculator {
             return false;
         }
         return scheduler.isDefunct(clock.millis()) && schedulerDao.isNotSelf(scheduler);
+    }
+
+    private boolean hasDefunctScheduler(Document lock) {
+        String schedulerId = lock.getString(Constants.LOCK_INSTANCE_ID);
+        return hasDefunctScheduler(schedulerId);
     }
 
     private boolean isLockExpired(Document lock, long timeoutMillis) {

--- a/src/test/groovy/com/novemberain/quartz/mongodb/util/ExpiryCalculatorTest.groovy
+++ b/src/test/groovy/com/novemberain/quartz/mongodb/util/ExpiryCalculatorTest.groovy
@@ -16,15 +16,22 @@ class ExpiryCalculatorTest extends Specification {
 
     def 'should tell if job lock has exired'() {
         given:
+        def timeInPast = -10000L
         def clock = Clocks.constClock(101)
         def calc = createCalc(clock)
+        def deadScheduler = createScheduler(timeInPast)
+        def deadCalc = createCalc(clock, deadScheduler)
 
         expect: 'Expired lock: 101 - 0 > 100 (timeout)'
         calc.isJobLockExpired(createDoc(0))
+        deadCalc.isJobLockExpired(createDoc(timeInPast))
 
         and: 'Not expired: 101 - 1/101 <= 100'
         !calc.isJobLockExpired(createDoc(1))
         !calc.isJobLockExpired(createDoc(101))
+
+        and: 'CheckIn expired'
+        deadCalc.isJobLockExpired(createDoc(10))
     }
 
     def 'should tell if trigger lock has expired'() {


### PR DESCRIPTION
I have 2 instances running in a cluster. My jobStore settings are the following:

```
spring.quartz.properties.org.quartz.scheduler.instanceName=SomeUniqInstanceName
spring.quartz.properties.org.quartz.scheduler.instanceId=AUTO
spring.quartz.properties.org.quartz.jobStore.class=com.novemberain.quartz.mongodb.MongoDBJobStore
spring.quartz.properties.org.quartz.jobStore.isClustered=true
spring.quartz.properties.org.quartz.jobStore.triggerTimeoutMillis=10000
spring.quartz.properties.org.quartz.jobStore.misfireThreshold=20000
spring.quartz.properties.org.quartz.jobStore.mongoUri=mongodb://localhost:27017
spring.quartz.properties.org.quartz.jobStore.dbName=quartzDB
```

So, I expect when 2 of my instances die I have a new ones and one of them
will aquire lock after CheckIn interval passes. Right now, my new
instances should wait for job to expire (default 10mins).

I don't want to reduce default jobExpire setting because my jobs might
takes up to 5 mins.