### PR TITLE
Fix for #155 DailyTimeIntervalTriggerProperties converter lost days o…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ idea {
 }
 dependencies {
     compile("org.quartz-scheduler:quartz:2.3.2")
-    compile("org.mongodb:mongodb-driver:3.9.1")
+    compile("org.mongodb:mongodb-driver:3.12.0")
     compile("commons-codec:commons-codec:1.10")
     compile("org.apache.commons:commons-lang3:3.8")
     compile("org.apache.httpcomponents:httpcore:4.4.10")

--- a/src/main/java/com/novemberain/quartz/mongodb/trigger/properties/DailyTimeIntervalTriggerPropertiesConverter.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/trigger/properties/DailyTimeIntervalTriggerPropertiesConverter.java
@@ -8,6 +8,11 @@ import org.quartz.impl.triggers.DailyTimeIntervalTriggerImpl;
 import org.quartz.spi.OperableTrigger;
 import org.quartz.DateBuilder;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 public class DailyTimeIntervalTriggerPropertiesConverter extends TriggerPropertiesConverter {
 
     private static final String TRIGGER_REPEAT_INTERVAL_UNIT = "repeatIntervalUnit";
@@ -15,6 +20,7 @@ public class DailyTimeIntervalTriggerPropertiesConverter extends TriggerProperti
     private static final String TRIGGER_TIMES_TRIGGERED = "timesTriggered";
     private static final String TRIGGER_START_TIME_OF_DAY = "startTimeOfDay";
     private static final String TRIGGER_END_TIME_OF_DAY = "endTimeOfDay";
+    private static final String TRIGGER_DAYS_OF_WEEK = "daysOfWeek";
 
     @Override
     protected boolean canHandle(OperableTrigger trigger) {
@@ -31,7 +37,8 @@ public class DailyTimeIntervalTriggerPropertiesConverter extends TriggerProperti
                 .append(TRIGGER_REPEAT_INTERVAL, t.getRepeatInterval())
                 .append(TRIGGER_TIMES_TRIGGERED, t.getTimesTriggered())
                 .append(TRIGGER_START_TIME_OF_DAY, toDocument(t.getStartTimeOfDay()))
-                .append(TRIGGER_END_TIME_OF_DAY, toDocument(t.getEndTimeOfDay()));
+                .append(TRIGGER_END_TIME_OF_DAY, toDocument(t.getEndTimeOfDay()))
+                .append(TRIGGER_DAYS_OF_WEEK, new ArrayList<>(t.getDaysOfWeek()));
     }
 
     private Document toDocument(TimeOfDay tod) {
@@ -65,6 +72,10 @@ public class DailyTimeIntervalTriggerPropertiesConverter extends TriggerProperti
         Document endTOD = (Document) stored.get(TRIGGER_END_TIME_OF_DAY);
         if (endTOD != null) {
             t.setEndTimeOfDay(fromDocument(endTOD));
+        }
+        List<Integer> daysOfWeek = stored.getList(TRIGGER_DAYS_OF_WEEK, Integer.class);
+        if (daysOfWeek != null) {
+            t.setDaysOfWeek(new HashSet<>(daysOfWeek));
         }
     }
 


### PR DESCRIPTION
This still seems to be an issue currently where DaysOfWeek is not set when saving down the trigger to mongo - this results in the days of week being defaulted to every day when the scheduler tries to read the trigger back out from mongo.