### PR TITLE
Migrated to new MongoDB Sync Driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 plugins {
     id 'net.researchgate.release' version '2.6.0'
     id "com.jfrog.bintray" version "1.7.3"
-    id 'com.sourcemuse.mongo' version '1.0.6'
+    id 'com.sourcemuse.mongo' version '1.0.7'
 }
 
 allprojects {
@@ -51,7 +51,7 @@ idea {
 }
 dependencies {
     compile("org.quartz-scheduler:quartz:2.3.2")
-    compile("org.mongodb:mongodb-driver:3.9.1")
+    compile("org.mongodb:mongodb-driver-sync:4.0.2")
     compile("commons-codec:commons-codec:1.10")
     compile("org.apache.commons:commons-lang3:3.8")
     compile("org.apache.httpcomponents:httpcore:4.4.10")
@@ -134,7 +134,7 @@ tasks.withType(Test){
         journalingEnabled true
         port 12345
         logging 'console'
-        mongoVersion '3.6.10'
+        mongoVersion '4.0.12'
     }
 }
 

--- a/src/main/java/com/novemberain/quartz/mongodb/DynamicMongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/DynamicMongoDBJobStore.java
@@ -1,6 +1,6 @@
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.novemberain.quartz.mongodb.clojure.DynamicClassLoadHelper;
 import org.quartz.spi.ClassLoadHelper;
 

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoDBJobStore.java
@@ -9,9 +9,9 @@
  */
 package com.novemberain.quartz.mongodb;
 
-import com.mongodb.MongoClient;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.novemberain.quartz.mongodb.db.MongoConnector;
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 public class MongoDBJobStore implements JobStore, Constants {
 
@@ -58,10 +59,9 @@ public class MongoDBJobStore implements JobStore, Constants {
 
     // Options for the Mongo client.
     Boolean mongoOptionSocketKeepAlive;
-    Integer mongoOptionMaxConnectionsPerHost;
+    Integer mongoOptionMaxConnections;
     Integer mongoOptionConnectTimeoutMillis;
-    Integer mongoOptionSocketTimeoutMillis; // read timeout
-    Integer mongoOptionThreadsAllowedToBlockForConnectionMultiplier;
+    Integer mongoOptionReadTimeoutMillis; // read timeout
     Boolean mongoOptionEnableSSL;
     Boolean mongoOptionSslInvalidHostNameAllowed;
     String mongoOptionTrustStorePath;
@@ -182,7 +182,7 @@ public class MongoDBJobStore implements JobStore, Constants {
 
     @Override
     public long getAcquireRetryDelay(int failureCount) {
-        return mongo.getMongoClientOptions().getServerSelectionTimeout();
+        return mongo.getClusterDescription().getClusterSettings().getServerSelectionTimeout(TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -601,20 +601,16 @@ public class MongoDBJobStore implements JobStore, Constants {
         }
     }
 
-    public void setMongoOptionMaxConnectionsPerHost(int maxConnectionsPerHost) {
-        this.mongoOptionMaxConnectionsPerHost = maxConnectionsPerHost;
+    public void setMongoOptionMaxConnections(int maxConnections) {
+        this.mongoOptionMaxConnections = maxConnections;
     }
 
     public void setMongoOptionConnectTimeoutMillis(int maxConnectWaitTime) {
         this.mongoOptionConnectTimeoutMillis = maxConnectWaitTime;
     }
 
-    public void setMongoOptionSocketTimeoutMillis(int socketTimeoutMillis) {
-        this.mongoOptionSocketTimeoutMillis = socketTimeoutMillis;
-    }
-
-    public void setMongoOptionThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
-        this.mongoOptionThreadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
+    public void setMongoOptionReadTimeoutMillis(int readTimeoutMillis) {
+        this.mongoOptionReadTimeoutMillis = readTimeoutMillis;
     }
 
     public void setMongoOptionSocketKeepAlive(boolean socketKeepAlive) {

--- a/src/main/java/com/novemberain/quartz/mongodb/MongoStoreAssembler.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/MongoStoreAssembler.java
@@ -93,7 +93,7 @@ public class MongoStoreAssembler {
         Runnable errorHandler;
         Class aClass;
         if (jobStore.getCheckInErrorHandler() == null) {
-            // current default, see 
+            // current default, see
             aClass = KamikazeErrorHandler.class;
         } else {
             aClass = loadHelper.loadClass(jobStore.getCheckInErrorHandler());
@@ -139,12 +139,10 @@ public class MongoStoreAssembler {
                 .withAddresses(jobStore.addresses)
                 .withDatabaseName(jobStore.dbName)
                 .withAuthDatabaseName(jobStore.authDbName)
-                .withMaxConnectionsPerHost(jobStore.mongoOptionMaxConnectionsPerHost)
+                .withMaxConnections(jobStore.mongoOptionMaxConnections)
                 .withConnectTimeoutMillis(jobStore.mongoOptionConnectTimeoutMillis)
-                .withSocketTimeoutMillis(jobStore.mongoOptionSocketTimeoutMillis)
+                .withReadTimeoutMillis(jobStore.mongoOptionReadTimeoutMillis)
                 .withSocketKeepAlive(jobStore.mongoOptionSocketKeepAlive)
-                .withThreadsAllowedToBlockForConnectionMultiplier(
-                        jobStore.mongoOptionThreadsAllowedToBlockForConnectionMultiplier)
                 .withSSL(jobStore.mongoOptionEnableSSL, jobStore.mongoOptionSslInvalidHostNameAllowed)
                 .withTrustStore(jobStore.mongoOptionTrustStorePath, jobStore.mongoOptionTrustStorePassword, jobStore.mongoOptionTrustStoreType)
                 .withKeyStore(jobStore.mongoOptionKeyStorePath, jobStore.mongoOptionKeyStorePassword, jobStore.mongoOptionKeyStoreType)

--- a/src/main/java/com/novemberain/quartz/mongodb/dao/CalendarDao.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/dao/CalendarDao.java
@@ -7,7 +7,6 @@ import org.quartz.Calendar;
 import org.quartz.JobPersistenceException;
 
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Projections;
@@ -40,12 +39,12 @@ public class CalendarDao {
     }
 
     public int getCount() {
-        return (int) calendarCollection.count();
+        return (int) calendarCollection.countDocuments();
     }
 
     public boolean remove(String name) {
         Bson searchObj = Filters.eq(CALENDAR_NAME, name);
-        if (calendarCollection.count(searchObj) > 0) {
+        if (calendarCollection.countDocuments(searchObj) > 0) {
             calendarCollection.deleteMany(searchObj);
             return true;
         }

--- a/src/main/java/com/novemberain/quartz/mongodb/dao/JobDao.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/dao/JobDao.java
@@ -54,7 +54,7 @@ public class JobDao {
     }
 
     public boolean exists(JobKey jobKey) {
-        return jobCollection.count(Keys.toFilter(jobKey)) > 0;
+        return jobCollection.countDocuments(Keys.toFilter(jobKey)) > 0;
     }
 
     public Document getById(Object id) {
@@ -70,7 +70,7 @@ public class JobDao {
     }
 
     public int getCount() {
-        return (int) jobCollection.count();
+        return (int) jobCollection.countDocuments();
     }
 
     public List<String> getGroupNames() {

--- a/src/main/java/com/novemberain/quartz/mongodb/dao/SchedulerDao.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/dao/SchedulerDao.java
@@ -1,6 +1,5 @@
 package com.novemberain.quartz.mongodb.dao;
 
-import com.mongodb.Block;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.*;
 import com.mongodb.client.result.DeleteResult;
@@ -14,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static com.mongodb.client.model.Sorts.ascending;
 
@@ -154,13 +154,8 @@ public class SchedulerDao {
                     .append(CHECKIN_INTERVAL_FIELD, clusterCheckinIntervalMillis));
     }
 
-    private Block<Document> createResultConverter(final List<Scheduler> schedulers) {
-        return new Block<Document>() {
-            @Override
-            public void apply(Document document) {
-                schedulers.add(toScheduler(document));
-            }
-        };
+    private Consumer<Document> createResultConverter(final List<Scheduler> schedulers) {
+        return document -> schedulers.add(toScheduler(document));
     }
 
     private Scheduler toScheduler(Document document) {

--- a/src/main/java/com/novemberain/quartz/mongodb/dao/TriggerDao.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/dao/TriggerDao.java
@@ -68,7 +68,7 @@ public class TriggerDao {
     }
 
     public boolean exists(Bson filter) {
-        return triggerCollection.count(filter) > 0;
+        return triggerCollection.countDocuments(filter) > 0;
     }
 
     public FindIterable<Document> findEligibleToRun(Date noLaterThanDate) {
@@ -84,7 +84,7 @@ public class TriggerDao {
     }
 
     public int getCount() {
-        return (int) triggerCollection.count();
+        return (int) triggerCollection.countDocuments();
     }
 
     public List<String> getGroupNames() {
@@ -209,7 +209,7 @@ public class TriggerDao {
     }
 
     private long getCount(Bson query) {
-        return triggerCollection.count(query);
+        return triggerCollection.countDocuments(query);
     }
 
     private void setStates(Bson filter, String state) {

--- a/src/main/java/com/novemberain/quartz/mongodb/db/ExternalMongoConnector.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/ExternalMongoConnector.java
@@ -1,7 +1,7 @@
 package com.novemberain.quartz.mongodb.db;
 
-import com.mongodb.MongoClient;
 import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;

--- a/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnector.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnector.java
@@ -1,7 +1,7 @@
 package com.novemberain.quartz.mongodb.db;
 
-import com.mongodb.MongoClient;
 import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import org.bson.Document;
 

--- a/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
@@ -1,11 +1,11 @@
 package com.novemberain.quartz.mongodb.db;
 
 import com.mongodb.*;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import org.quartz.SchedulerConfigException;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -30,11 +30,10 @@ public class MongoConnectorBuilder {
     private String username;
     private String password;
     private String authDbName;
-    private Integer maxConnectionsPerHost;
+    private Integer maxConnections;
     private Integer connectTimeoutMillis;
-    private Integer socketTimeoutMillis;
+    private Integer readTimeoutMillis;
     private Boolean socketKeepAlive;
-    private Integer threadsAllowedToBlockForConnectionMultiplier;
     private Boolean enableSSL;
     private Boolean sslInvalidHostNameAllowed;
     private String trustStorePath;
@@ -91,17 +90,17 @@ public class MongoConnectorBuilder {
             return new ExternalMongoConnector(writeConcern, client, dbName);
         }
 
-        final MongoClientOptions.Builder optionsBuilder = createOptionBuilder();
+        final MongoClientSettings.Builder settingsBuilder = createSettingsBuilder();
         if (uri != null) {
             // User passed URI.
             validateForUri();
-            return new InternalMongoConnector(writeConcern, uri, dbName, optionsBuilder);
+            return new InternalMongoConnector(writeConcern, uri, dbName, settingsBuilder);
         }
 
         checkNotNull(addresses, "At least one MongoDB address or a MongoDB URI must be specified.");
         final List<ServerAddress> serverAddresses = collectServerAddresses();
         final Optional<MongoCredential> credentials = createCredentials();
-        return new InternalMongoConnector(writeConcern, serverAddresses, credentials, optionsBuilder.build(), dbName);
+        return new InternalMongoConnector(writeConcern, serverAddresses, credentials, settingsBuilder.build(), dbName);
     }
 
     private List<ServerAddress> collectServerAddresses() {
@@ -127,45 +126,42 @@ public class MongoConnectorBuilder {
         return Optional.empty();
     }
 
-    private MongoClientOptions.Builder createOptionBuilder() throws SchedulerConfigException {
-        final MongoClientOptions.Builder optionsBuilder = MongoClientOptions.builder();
-        if (maxConnectionsPerHost != null) {
-            optionsBuilder.connectionsPerHost(maxConnectionsPerHost);
+    private MongoClientSettings.Builder createSettingsBuilder() throws SchedulerConfigException {
+        final MongoClientSettings.Builder settingsBuilder = MongoClientSettings.builder();
+        if (maxConnections != null) {
+            settingsBuilder.applyToConnectionPoolSettings(builder -> builder.maxSize(maxConnections));
         }
         if (connectTimeoutMillis != null) {
-            optionsBuilder.connectTimeout(connectTimeoutMillis);
+            settingsBuilder.applyToSocketSettings(builder -> builder.connectTimeout(connectTimeoutMillis, TimeUnit.MILLISECONDS));
         }
-        if (socketTimeoutMillis != null) {
-            optionsBuilder.socketTimeout(socketTimeoutMillis);
+        if (readTimeoutMillis != null) {
+            settingsBuilder.applyToSocketSettings(builder -> builder.readTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS));
         }
         if (socketKeepAlive != null) {
             // enabled by default,
             // ignored per MongoDB Java client deprecations
         }
-        if (threadsAllowedToBlockForConnectionMultiplier != null) {
-            optionsBuilder.threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier);
-        }
-        hanldeSSLContext(optionsBuilder);
-        return optionsBuilder;
+        hanldeSSLContext(settingsBuilder);
+        return settingsBuilder;
     }
 
-    private void hanldeSSLContext(MongoClientOptions.Builder optionsBuilder) throws SchedulerConfigException {
+    private void hanldeSSLContext(MongoClientSettings.Builder optionsBuilder) throws SchedulerConfigException {
         try {
             SSLContext sslContext = sslContextFactory.getSSLContext(trustStorePath, trustStorePassword, trustStoreType,
                     keyStorePath, keyStorePassword, keyStoreType);
             if (sslContext == null) {
                 if (enableSSL != null) {
-                    optionsBuilder.sslEnabled(enableSSL);
+                    optionsBuilder.applyToSslSettings(builder -> builder.enabled(enableSSL));
                     if (sslInvalidHostNameAllowed != null) {
-                        optionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
+                        optionsBuilder.applyToSslSettings(builder -> builder.invalidHostNameAllowed(sslInvalidHostNameAllowed));
                     }
                 }
             } else {
-                optionsBuilder.sslEnabled(true);
+                optionsBuilder.applyToSslSettings(builder -> builder.enabled(true));
                 if (sslInvalidHostNameAllowed != null) {
-                    optionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
+                    optionsBuilder.applyToSslSettings(builder -> builder.invalidHostNameAllowed(sslInvalidHostNameAllowed));
                 }
-                optionsBuilder.sslContext(sslContext);
+                optionsBuilder.applyToSslSettings(builder -> builder.context(sslContext));
             }
         } catch (SSLException e) {
             throw new SchedulerConfigException("Cannot setup SSL context", e);
@@ -244,12 +240,10 @@ public class MongoConnectorBuilder {
     }
 
     private void checkConnectionOptionsAreNull(final String suffix) throws SchedulerConfigException {
-        checkIsNull(maxConnectionsPerHost, paramNotAllowed("Max connections per host", suffix));
+        checkIsNull(maxConnections, paramNotAllowed("Max connections", suffix));
         checkIsNull(connectTimeoutMillis, paramNotAllowed("Connect timeout millis", suffix));
-        checkIsNull(socketTimeoutMillis, paramNotAllowed("Socket timeout millis", suffix));
+        checkIsNull(readTimeoutMillis, paramNotAllowed("Socket timeout millis", suffix));
         checkIsNull(socketKeepAlive, paramNotAllowed("Socket keepAlive", suffix));
-        checkIsNull(threadsAllowedToBlockForConnectionMultiplier,
-                paramNotAllowed("Threads allowed to block for connection multiplier", suffix));
         checkIsNull(enableSSL, paramNotAllowed("Enable ssl", suffix));
         checkIsNull(sslInvalidHostNameAllowed, paramNotAllowed("SSL invalid hostname allowed", suffix));
         checkIsNull(trustStorePath, paramNotAllowed("TrustStore path", suffix));
@@ -317,8 +311,8 @@ public class MongoConnectorBuilder {
         return this;
     }
 
-    public MongoConnectorBuilder withMaxConnectionsPerHost(final Integer maxConnectionsPerHost) {
-        this.maxConnectionsPerHost = maxConnectionsPerHost;
+    public MongoConnectorBuilder withMaxConnections(final Integer maxConnections) {
+        this.maxConnections = maxConnections;
         return this;
     }
 
@@ -327,19 +321,13 @@ public class MongoConnectorBuilder {
         return this;
     }
 
-    public MongoConnectorBuilder withSocketTimeoutMillis(final Integer socketTimeoutMillis) {
-        this.socketTimeoutMillis = socketTimeoutMillis;
+    public MongoConnectorBuilder withReadTimeoutMillis(final Integer readTimeoutMillis) {
+        this.readTimeoutMillis = readTimeoutMillis;
         return this;
     }
 
     public MongoConnectorBuilder withSocketKeepAlive(final Boolean socketKeepAlive) {
         this.socketKeepAlive = socketKeepAlive;
-        return this;
-    }
-
-    public MongoConnectorBuilder withThreadsAllowedToBlockForConnectionMultiplier(
-            final Integer threadsAllowedToBlockForConnectionMultiplier) {
-        this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
         return this;
     }
 

--- a/src/test/groovy/com/novemberain/quartz/mongodb/MongoHelper.groovy
+++ b/src/test/groovy/com/novemberain/quartz/mongodb/MongoHelper.groovy
@@ -1,9 +1,10 @@
 package com.novemberain.quartz.mongodb
 
-import com.mongodb.MongoClient
-import com.mongodb.MongoClientOptions
-import com.mongodb.ServerAddress;
+import com.mongodb.MongoClientSettings
+import com.mongodb.ServerAddress
 import com.mongodb.WriteConcern
+import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
 import org.bson.Document
@@ -14,10 +15,12 @@ class MongoHelper {
 
     static DEFAULT_MONGO_PORT = 12345
 
-    static MongoClient client = new MongoClient(
-            new ServerAddress('localhost', DEFAULT_MONGO_PORT),
-            MongoClientOptions.builder()
+    static MongoClient client = MongoClients.create(
+            MongoClientSettings.builder()
                     .writeConcern(WriteConcern.JOURNALED)
+                    .applyToClusterSettings { builder ->
+                        builder.hosts([new ServerAddress('localhost', DEFAULT_MONGO_PORT)])
+                    }
                     .build())
 
     static MongoDatabase testDatabase = client.getDatabase(testDatabaseName)
@@ -83,7 +86,7 @@ class MongoHelper {
      * Return number of elements in a collection.
      */
     static def getCount(String col) {
-        collections[col].count()
+        collections[col].countDocuments()
     }
 
     /**


### PR DESCRIPTION
`quartz-mongodb` still relies on the old MongoDB Legacy Driver. This pull requests uses the MongoDB Sync Driver 4.0.2.

I'm using `mongodb-driver-reactivestreams` 4.x in a project and cannot use `quartz-mongodb` as-is because the 4.x driver is incompatible with the legacy driver.

Note that some public API has changed as the configuration of `MongoClients` has changed.
**This is a major update!**