### PR TITLE
Update TriggerRunner.java

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/TriggerRunner.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/TriggerRunner.java
@@ -95,11 +95,12 @@ public class TriggerRunner {
                     lockManager.unlockExpired(job);
                 }
             }
-            }
+
+        }
+        }
         catch(MongoException e) {
    		 log.error("acquireNextTriggers failed due to MongoException: " + e.getMessage(), e);
             throw new JobPersistenceException("acquireNextTriggers failed due to MongoException: "  , e);
-        }
         }
         return results;
     }
@@ -131,7 +132,9 @@ public class TriggerRunner {
                     log.info("Acquired trigger: {}", trigger.getKey());
                     triggers.put(trigger.getKey(), trigger);
                 } else {
+                	triggers.put(trigger.getKey(), trigger);
                     lockManager.unlockAcquiredTrigger(trigger);
+                    triggers.remove(trigger.getKey());
                 }
             } else if (lockManager.relockExpired(key)) {
                 log.info("Recovering trigger: {}", trigger.getKey());
@@ -151,6 +154,7 @@ public class TriggerRunner {
         	 log.error("acquireNextTriggers failed due to MongoException: " + e.getMessage(), e);
              throw new JobPersistenceException("acquireNextTriggers failed due to MongoException: "  , e);
         }
+
 
         return new ArrayList<OperableTrigger>(triggers.values());
     }


### PR DESCRIPTION
quartz no longer relock when lock expires and does not execute job when TriggerAndJobPersister.storeTrigger unable to connect mongo for a moment
https://github.com/michaelklishin/quartz-mongodb/issues/192

As we are not handling MongoException after trigger lock(Mongo down for a moment where checkin task is able to access mongo). That lock can not be relocked or expired .
https://github.com/michaelklishin/quartz-mongodb/issues/114#issuecomment-366423026