### PR TITLE
Ensure that the created jar is compatible with Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ repositories {
     mavenCentral()
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 configurations {
     provided
     implementation.extendsFrom provided


### PR DESCRIPTION
Hi,

the java compatibility parameters for the build output have been removed with some dependency upgrades for the recent version 2.2.0-rc1. As a result, the version does not work on java versions smaller than 13 with exceptions such as:

`java.lang.UnsupportedClassVersionError: com/novemberain/quartz/mongodb/MongoDBJobStore has been compiled by a more recent version of the Java Runtime (class file version 57.0), this version of the Java Runtime only recognizes class file versions up to 52.0`

Is this a permanent change or is this unintended? If it's the latter: I added Java 8 compatibility back into the project with this pull request.

Thanks for your work :)