### PR TITLE
Scheduler cannot remove own expired lock

### DIFF
--- a/src/main/java/com/novemberain/quartz/mongodb/util/ExpiryCalculator.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/util/ExpiryCalculator.java
@@ -34,18 +34,18 @@ public class ExpiryCalculator {
 
     public boolean isTriggerLockExpired(Document lock) {
         String schedulerId = lock.getString(Constants.LOCK_INSTANCE_ID);
-        return isLockExpired(lock, triggerTimeoutMillis) && hasDefunctScheduler(schedulerId);
+        return isLockExpired(lock, triggerTimeoutMillis) || hasDefunctScheduler(schedulerId);
     }
 
     private boolean hasDefunctScheduler(String schedulerId) {
-        
+
         Scheduler scheduler = schedulerDao.findInstance(schedulerId);
         if (scheduler == null) {
             log.debug("No such scheduler: {}", schedulerId);
             return false;
         }
         return scheduler.isDefunct(clock.millis()) && schedulerDao.isNotSelf(scheduler);
-        
+
     }
 
     private boolean hasDefunctScheduler(Document lock) {

--- a/src/test/groovy/com/novemberain/quartz/mongodb/util/ExpiryCalculatorTest.groovy
+++ b/src/test/groovy/com/novemberain/quartz/mongodb/util/ExpiryCalculatorTest.groovy
@@ -44,7 +44,7 @@ class ExpiryCalculatorTest extends Specification {
         def calc = createCalc(clock, aliveScheduler)
 
         then: 'Expired lock: 10001 - 0 > 10000 (timeout)'
-        !calc.isTriggerLockExpired(createDoc(0))
+        calc.isTriggerLockExpired(createDoc(0))
 
         and: 'Not expired: 101 - 1/10001 <= 10000'
         !calc.isTriggerLockExpired(createDoc(1))
@@ -52,14 +52,14 @@ class ExpiryCalculatorTest extends Specification {
 
         when: 'Tests for dead scheduler'
         def deadScheduler = createScheduler(0) // lastCheckinTime = 0
-        calc = createCalc(clock, deadScheduler)
+        def deadCalc = createCalc(clock, deadScheduler)
 
         then: 'Expired lock: 10001 - 0 > 10000 (timeout)'
-        calc.isTriggerLockExpired(createDoc(0))
+        deadCalc.isTriggerLockExpired(createDoc(0))
 
         and: 'Not expired: 10001 - 1/10001 <= 10000'
-        !calc.isTriggerLockExpired(createDoc(1))
-        !calc.isTriggerLockExpired(createDoc(10001))
+        deadCalc.isTriggerLockExpired(createDoc(1))
+        deadCalc.isTriggerLockExpired(createDoc(10001))
     }
 
     def Scheduler createScheduler() {


### PR DESCRIPTION
- Change the isTriggerLockExpired to as like isJobLockExpired


Schedular | Trigger Timeout | isTriggerLockExpired
-- | -- | --
ALIVE | Yes | TRUE
ALIVE | No | FALSE
DEAD | Yes | TRUE
DEAD | No | TRUE

Fix of #196 