### PR TITLE
Allow credentials to be added to MongoClientSettings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ lib/*
 *~
 src/legacytest/*
 checkouts/*
+bin

--- a/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
@@ -152,7 +152,7 @@ public class MongoConnectorBuilder {
             // enabled by default,
             // ignored per MongoDB Java client deprecations
         }
-        if (username != null && username != null && username != null) {
+        if (username != null && authDbName != null && password != null) {
 	        MongoCredential credential =
             MongoCredential.createScramSha1Credential(
                 username, authDbName, password.toCharArray());

--- a/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
+++ b/src/main/java/com/novemberain/quartz/mongodb/db/MongoConnectorBuilder.java
@@ -152,6 +152,12 @@ public class MongoConnectorBuilder {
             // enabled by default,
             // ignored per MongoDB Java client deprecations
         }
+        if (username != null && username != null && username != null) {
+	        MongoCredential credential =
+            MongoCredential.createScramSha1Credential(
+                username, authDbName, password.toCharArray());
+        	settingsBuilder.credential(credential);
+        }
         hanldeSSLContext(settingsBuilder);
         return settingsBuilder;
     }
@@ -245,9 +251,6 @@ public class MongoConnectorBuilder {
 
     private void checkServerPropertiesAreNull(final String suffix) throws SchedulerConfigException {
         checkIsNull(addresses, paramNotAllowed("Addresses array", suffix));
-        checkIsNull(username, paramNotAllowed("Username", suffix));
-        checkIsNull(password, paramNotAllowed("Password", suffix));
-        checkIsNull(authDbName, paramNotAllowed("Auth database name", suffix));
     }
 
     private void checkConnectionOptionsAreNull(final String suffix) throws SchedulerConfigException {


### PR DESCRIPTION
This allows a uri to be defined without credentials and the credential be added on use.

The newer client APIs allow for this method - and it is bad practise to hard code credentials.

In my case, I store the mongo URI as part of a container config and the credentials as a secret and then combine when starting the container.

````
  @Bean
  public SchedulerFactoryBean schedulerFactoryBean(SecretReader reader, MongoProperties mongo, QuartzProperties properties) {
    Properties qp = properties.getQuartz();
    qp.put("org.quartz.jobStore.mongoUri", mongo.determineUri());   
    
    Optional<Secret> osecret = reader.getSecret();    
    if (osecret.isPresent()) {
      Secret secret = osecret.get();
      qp.put("org.quartz.jobStore.authDbName","admin");
      qp.put("org.quartz.jobStore.username",secret.dbUser);
      qp.put("org.quartz.jobStore.password",secret.dbPassword);
    } else if (mongo.getUsername() != null && mongo.getPassword() != null) {
        qp.put("org.quartz.jobStore.authDbName","admin");
        qp.put("org.quartz.jobStore.username",mongo.getUsername());
        qp.put("org.quartz.jobStore.password",new String(mongo.getPassword()));
    }
    
    SchedulerFactoryBean scheduler = new SchedulerFactoryBean();    

    scheduler.setQuartzProperties(qp);
    scheduler.setStartupDelay(20);
    scheduler.setWaitForJobsToCompleteOnShutdown(true);

    AutowiringSpringBeanJobFactory jobFac = new AutowiringSpringBeanJobFactory();
    jobFac.setApplicationContext(context);
    scheduler.setJobFactory(jobFac);

    return scheduler;
  }
````